### PR TITLE
fix: make crate usable in no_std environments

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-on: 
+on:
   push:
     branches:
       - main
@@ -21,20 +21,20 @@ jobs:
         with:
           command: check
 
-  #check_nostd:
-  #  name: Check (no_std)
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - uses: actions-rs/toolchain@v1
-  #      with:
-  #        profile: minimal
-  #        toolchain: stable
-  #        override: true
-  #    - uses: actions-rs/cargo@v1
-  #      with:
-  #        command: check
-  #        args: --no-default-features
+  check_nostd:
+   name: Check (no_std)
+   runs-on: ubuntu-latest
+   steps:
+     - uses: actions/checkout@v2
+     - uses: actions-rs/toolchain@v1
+       with:
+         profile: minimal
+         toolchain: stable
+         override: true
+     - uses: actions-rs/cargo@v1
+       with:
+         command: check
+         args: --no-default-features
 
   test:
     name: Test Suite
@@ -50,21 +50,20 @@ jobs:
         with:
           command: test
 
-  #test_nostd:
-  #  name: Test Suite (no_std)
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - uses: actions-rs/toolchain@v1
-  #      with:
-  #        profile: minimal
-  #        toolchain: stable
-  #        override: true
-  #    - uses: actions-rs/cargo@v1
-  #      with:
-  #        command: test
-  #        args: --no-default-features
-  #
+  test_nostd:
+   name: Test Suite (no_std)
+   runs-on: ubuntu-latest
+   steps:
+     - uses: actions/checkout@v2
+     - uses: actions-rs/toolchain@v1
+       with:
+         profile: minimal
+         toolchain: stable
+         override: true
+     - uses: actions-rs/cargo@v1
+       with:
+         command: test
+         args: --no-default-features
 
   fmt:
     name: Rustfmt

--- a/src/common/cbor_map/mod.rs
+++ b/src/common/cbor_map/mod.rs
@@ -366,6 +366,7 @@ mod private {
 /// Contains methods to convert `CborMap` structs (so actually, types implementing `ToCborMap`)
 /// into CBOR and back.
 mod conversion {
+    #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
     use ciborium::value::Value;
     use serde::de::{Error, Unexpected};

--- a/src/common/cbor_map/mod.rs
+++ b/src/common/cbor_map/mod.rs
@@ -20,6 +20,7 @@
 //! # use dcaf::{AccessTokenRequest, ToCborMap};
 //! # use dcaf::endpoints::token_req::AccessTokenRequestBuilderError;
 //! # use crate::dcaf::constants::cbor_abbreviations::token::CLIENT_ID;
+//! # #[cfg(feature = "std")] {
 //! let request: AccessTokenRequest = AccessTokenRequest::builder().client_id("test").build()?;
 //! let mut serialized = Vec::new();
 //! request.serialize_into(&mut serialized)?;
@@ -30,6 +31,7 @@
 //! 0x64, // text(4)
 //! 0x74, 0x65, 0x73, 0x74 // "test"
 //! ]);
+//! # }
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 //! If we then want to deserialize it again:

--- a/src/common/cbor_map/mod.rs
+++ b/src/common/cbor_map/mod.rs
@@ -45,13 +45,17 @@
 //!
 //! [`AccessTokenRequest`]: crate::AccessTokenRequest
 
-use alloc::boxed::Box;
-use alloc::vec::Vec;
 use core::fmt::{Debug, Display, Formatter};
+
+#[cfg(feature = "std")]
 use std::any::type_name;
 
 use ciborium::de::from_reader;
 use ciborium::ser::into_writer;
+
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::format, alloc::vec::Vec, core::any::type_name};
+
 use ciborium::value::{Integer, Value};
 use ciborium_io::{Read, Write};
 use erased_serde::Serialize as ErasedSerialize;
@@ -362,6 +366,7 @@ mod private {
 /// Contains methods to convert `CborMap` structs (so actually, types implementing `ToCborMap`)
 /// into CBOR and back.
 mod conversion {
+    use alloc::vec::Vec;
     use ciborium::value::Value;
     use serde::de::{Error, Unexpected};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/common/cbor_values/mod.rs
+++ b/src/common/cbor_values/mod.rs
@@ -26,10 +26,12 @@
 //! # Ok::<(), AccessTokenResponseBuilderError>(())
 //! ```
 
-use alloc::vec::Vec;
 use core::fmt::{Debug, Display, Formatter};
 use core::ops::Deref;
 use strum_macros::IntoStaticStr;
+
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::format, alloc::vec, alloc::vec::Vec};
 
 use coset::{CoseEncrypt0, CoseKey};
 

--- a/src/common/scope/mod.rs
+++ b/src/common/scope/mod.rs
@@ -23,6 +23,7 @@
 //! # use dcaf::error::{InvalidBinaryEncodedScopeError, InvalidTextEncodedScopeError};
 //! # use dcaf::{AifEncodedScope, Scope};
 //! // Will be encoded with a space-separator.
+//! # #[cfg(feature = "std")] {
 //! let text_scope = TextEncodedScope::try_from(vec!["first_client", "second_client"])?;
 //! assert_eq!(text_scope.to_string(), "first_client second_client");
 //! assert!(text_scope.elements().eq(vec!["first_client", "second_client"]));
@@ -30,6 +31,7 @@
 //! // Separator is only specified upon `elements` call.
 //! let binary_scope = BinaryEncodedScope::try_from(vec![1, 2, 0, 3, 4].as_slice())?;
 //! assert!(binary_scope.elements(Some(0))?.eq(&vec![&vec![1, 2], &vec![3, 4]]));
+//! # }
 //!
 //! // Will be encoded as path and REST-method-set pairs.
 //! let aif_scope = AifEncodedScope::from(vec![
@@ -48,11 +50,13 @@
 //! # use dcaf::common::scope::{BinaryEncodedScope, TextEncodedScope};
 //! # use dcaf::{AuthServerRequestCreationHint, Scope};
 //! # use dcaf::endpoints::creation_hint::AuthServerRequestCreationHintBuilderError;
+//! # #[cfg(feature = "std")] {
 //! # let text_scope = TextEncodedScope::try_from(vec!["first_client", "second_client"])?;
 //! # let original_scope = text_scope.clone();
 //! # let binary_scope = BinaryEncodedScope::try_from(vec![1, 2, 0, 3, 4].as_slice())?;
 //! let hint: AuthServerRequestCreationHint = AuthServerRequestCreationHint::builder().scope(Scope::from(text_scope)).build()?;
 //! # assert_eq!(hint.scope, Some(Scope::from(original_scope)));
+//! # }
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 //! This works with the binary encoded scope too, of course:
@@ -61,10 +65,12 @@
 //! # use dcaf::common::scope::{BinaryEncodedScope, TextEncodedScope};
 //! # use dcaf::{AuthServerRequestCreationHint, Scope};
 //! # use dcaf::endpoints::creation_hint::AuthServerRequestCreationHintBuilderError;
+//! # #[cfg(feature = "std")] {
 //! # let binary_scope = BinaryEncodedScope::try_from(vec![1, 2, 0, 3, 4].as_slice())?;
 //! # let original_scope = binary_scope.clone();
 //! let hint: AuthServerRequestCreationHint = AuthServerRequestCreationHint::builder().scope(Scope::from(binary_scope)).build()?;
 //! # assert_eq!(hint.scope, Some(Scope::from(original_scope)));
+//! # }
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 //! As well as with the AIF-encoded scope:
@@ -77,8 +83,10 @@
 //! #    ("/s/temp", AifRestMethod::Get.into()), ("/none", AifRestMethodSet::empty())
 //! # ]);
 //! # let original_scope = aif_scope.clone();
+//! # #[cfg(feature = "std")] {
 //! let hint: AuthServerRequestCreationHint = AuthServerRequestCreationHint::builder().scope(Scope::from(aif_scope)).build()?;
 //! # assert_eq!(hint.scope, Some(Scope::from(original_scope)));
+//! # }
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 //!
@@ -449,9 +457,11 @@ pub struct LibdcafEncodedScope(AifEncodedScopeElement);
 /// # use std::error::Error;
 /// # use dcaf::common::scope::{BinaryEncodedScope, Scope, TextEncodedScope, AifEncodedScope, AifRestMethod};
 /// # use dcaf::error::{InvalidTextEncodedScopeError, InvalidBinaryEncodedScopeError};
+/// # #[cfg(feature = "std")] {
 /// let text_scope = Scope::from(TextEncodedScope::try_from("dcaf rs")?);
 /// let binary_scope = Scope::from(BinaryEncodedScope::try_from(vec![0xDC, 0xAF].as_slice())?);
 /// let aif_scope = Scope::from(AifEncodedScope::from(vec![("/tmp", AifRestMethod::Get.into())]));
+/// # }
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```
 ///

--- a/src/common/scope/mod.rs
+++ b/src/common/scope/mod.rs
@@ -89,7 +89,9 @@
 //! [`draft-ietf-ace-oauth-authz`, section 5.8.1](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8.1-2.4).
 //! AIF is defined in [`draft-ietf-ace-aif`](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-3).
 
-use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use {alloc::string::String, alloc::string::ToString, alloc::vec, alloc::vec::Vec};
+
 use core::fmt::{Display, Formatter};
 
 use enumflags2::{bitflags, BitFlags};

--- a/src/common/scope/tests.rs
+++ b/src/common/scope/tests.rs
@@ -11,6 +11,9 @@
 
 /// Tests for text encoded scopes.
 mod text {
+    #[cfg(not(feature = "std"))]
+    use {alloc::vec, alloc::vec::Vec};
+
     use ciborium::value::Value;
 
     use crate::common::scope::TextEncodedScope;
@@ -136,6 +139,13 @@ mod text {
 }
 
 mod aif {
+    #[cfg(not(feature = "std"))]
+    use {
+        alloc::string::{String, ToString},
+        alloc::vec,
+        alloc::vec::Vec,
+    };
+
     use ciborium::de::from_reader;
     use ciborium::ser::into_writer;
     use enumflags2::{make_bitflags, BitFlags};
@@ -264,6 +274,9 @@ mod aif {
 }
 
 mod libdcaf {
+    #[cfg(not(feature = "std"))]
+    use {alloc::string::ToString, alloc::vec};
+
     use ciborium::de::from_reader;
 
     use crate::error::InvalidAifEncodedScopeError;
@@ -319,6 +332,9 @@ mod libdcaf {
 
 /// Tests for binary encoded scopes.
 mod binary {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
     use ciborium::value::Value;
 
     use crate::common::scope::BinaryEncodedScope;

--- a/src/common/test_helper.rs
+++ b/src/common/test_helper.rs
@@ -22,6 +22,13 @@ use core::fmt::Debug;
 use coset::iana::Algorithm;
 use coset::{Header, Label};
 
+#[cfg(not(feature = "std"))]
+use {
+    alloc::string::{String, ToString},
+    alloc::vec,
+    alloc::vec::Vec,
+};
+
 /// Helper function for tests which ensures that [`value`] serializes to the hexadecimal bytestring
 /// [expected_hex] and deserializes back to [`value`].
 ///

--- a/src/endpoints/creation_hint/mod.rs
+++ b/src/endpoints/creation_hint/mod.rs
@@ -17,7 +17,9 @@
 
 use crate::common::cbor_values::ByteString;
 use crate::Scope;
-use alloc::string::String;
+
+#[cfg(not(feature = "std"))]
+use {alloc::string::String, alloc::vec::Vec};
 
 #[cfg(test)]
 mod tests;
@@ -125,6 +127,10 @@ mod builder {
 /// models which are represented as CBOR maps.
 mod conversion {
     use crate::common::cbor_map::{cbor_map_vec, decode_scope, ToCborMap};
+
+    #[cfg(not(feature = "std"))]
+    use alloc::boxed::Box;
+
     use ciborium::value::Value;
     use erased_serde::Serialize as ErasedSerialize;
 

--- a/src/endpoints/creation_hint/mod.rs
+++ b/src/endpoints/creation_hint/mod.rs
@@ -55,6 +55,7 @@ mod tests;
 /// # use dcaf::error::InvalidTextEncodedScopeError;
 /// // Scope could be built from TextEncodedScope too,
 /// // which also offers to take a space-separated string.
+/// # #[cfg(feature = "std")] {
 /// let scope = Scope::try_from(vec!["rTempC"])?;
 /// let hint: AuthServerRequestCreationHint = AuthServerRequestCreationHint::builder()
 ///     .auth_server("coaps://as.example.com/token")
@@ -65,6 +66,7 @@ mod tests;
 /// let mut serialized = Vec::new();
 /// hint.clone().serialize_into(&mut serialized)?;
 /// assert_eq!(AuthServerRequestCreationHint::deserialize_from(serialized.as_slice())?, hint);
+/// # }
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```
 ///

--- a/src/endpoints/creation_hint/tests.rs
+++ b/src/endpoints/creation_hint/tests.rs
@@ -9,6 +9,9 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
 
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use enumflags2::{make_bitflags, BitFlags};
 
 use crate::common::scope::{AifRestMethod, TextEncodedScope};

--- a/src/endpoints/token_req/mod.rs
+++ b/src/endpoints/token_req/mod.rs
@@ -18,8 +18,10 @@
 
 use crate::common::cbor_values::{ByteString, ProofOfPossessionKey};
 use crate::Scope;
-use alloc::string::String;
 use coset::AsCborValue;
+
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::string::String, alloc::vec::Vec};
 
 #[cfg(test)]
 mod tests;
@@ -621,6 +623,9 @@ mod conversion {
     use ciborium::value::Value;
     use coset::cwt::Timestamp;
     use erased_serde::Serialize as ErasedSerialize;
+
+    #[cfg(not(feature = "std"))]
+    use {alloc::borrow::ToOwned, alloc::string::ToString};
 
     use crate::endpoints::token_req::AceProfile::CoapDtls;
     use crate::error::TryFromCborMapError;

--- a/src/endpoints/token_req/mod.rs
+++ b/src/endpoints/token_req/mod.rs
@@ -121,6 +121,7 @@ pub enum GrantType {
 /// # use dcaf::{ToCborMap, AccessTokenRequest, Scope};
 /// # use dcaf::endpoints::token_req::AccessTokenRequestBuilderError;
 /// # use dcaf::error::InvalidTextEncodedScopeError;
+/// # #[cfg(feature = "std")] {
 /// let request: AccessTokenRequest = AccessTokenRequest::builder()
 ///    .client_id("myclient")
 ///    .audience("tempSensor4711")
@@ -128,6 +129,7 @@ pub enum GrantType {
 /// let mut serialized = Vec::new();
 /// request.clone().serialize_into(&mut serialized)?;
 /// assert_eq!(AccessTokenRequest::deserialize_from(serialized.as_slice())?, request);
+/// # }
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```
 ///
@@ -342,6 +344,7 @@ pub enum AceProfile {
 /// #         0x42, 0x71, 0x08]
 /// ).key_id(vec![0xDF, 0xD1, 0xAA, 0x97]).build();
 /// let expires_in: u32 = 3600;  // this needs to be done so Rust doesn't think of it as an i32
+/// # #[cfg(feature = "std")] {
 /// let response: AccessTokenResponse = AccessTokenResponse::builder()
 ///    .access_token(
 ///       // Omitted for brevity, this is a CWT whose `cnf` claim contains
@@ -356,6 +359,7 @@ pub enum AceProfile {
 /// let mut serialized = Vec::new();
 /// response.clone().serialize_into(&mut serialized)?;
 /// assert_eq!(AccessTokenResponse::deserialize_from(serialized.as_slice())?, response);
+/// # }
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```
 ///
@@ -517,12 +521,14 @@ pub enum ErrorCode {
 /// # use ciborium_io::{Read, Write};
 /// # use dcaf::{ToCborMap, ErrorCode, ErrorResponse};
 /// # use dcaf::endpoints::token_req::ErrorResponseBuilderError;
+/// # #[cfg(feature = "std")] {
 /// let error: ErrorResponse = ErrorResponse::builder()
 ///     .error(ErrorCode::InvalidRequest)
 ///     .build()?;
 /// let mut serialized = Vec::new();
 /// error.clone().serialize_into(&mut serialized)?;
 /// assert_eq!(ErrorResponse::deserialize_from(serialized.as_slice())?, error);
+/// # }
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```
 ///

--- a/src/endpoints/token_req/tests.rs
+++ b/src/endpoints/token_req/tests.rs
@@ -9,6 +9,9 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
 
+#[cfg(not(feature = "std"))]
+use {alloc::string::ToString, alloc::vec};
+
 use coset::cwt::Timestamp;
 use coset::iana::Algorithm;
 use coset::{

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -11,10 +11,17 @@
 
 //! Contains error types used across this crate.
 
+#[cfg(feature = "std")]
+use {std::marker::PhantomData, std::num::TryFromIntError};
+
+#[cfg(not(feature = "std"))]
+use {
+    alloc::format, alloc::string::String, alloc::string::ToString, core::num::TryFromIntError,
+    derive_builder::export::core::marker::PhantomData,
+};
+
 use core::any::type_name;
 use core::fmt::{Display, Formatter};
-use std::marker::PhantomData;
-use std::num::TryFromIntError;
 
 use ciborium::value::Value;
 use coset::{CoseError, Label};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,7 @@
     clippy::wildcard_imports
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
+#[macro_use]
 extern crate alloc;
 extern crate core;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@
 //! # use std::error::Error;
 //! use dcaf::{AccessTokenRequest, ToCborMap, ProofOfPossessionKey, TextEncodedScope};
 //!
+//! # #[cfg(feature = "std")] {
 //! let request = AccessTokenRequest::builder()
 //!    .client_id("myclient")
 //!    .audience("valve242")
@@ -76,6 +77,7 @@
 //! let mut encoded = Vec::new();
 //! request.clone().serialize_into(&mut encoded)?;
 //! assert_eq!(AccessTokenRequest::deserialize_from(encoded.as_slice())?, request);
+//! # }
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 //!

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -83,6 +83,9 @@
 //! # Ok::<(), AccessTokenError<String>>(())
 //! ```
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::common::cbor_values::ByteString;
 use core::fmt::{Debug, Display};
 use coset::cwt::ClaimsSet;

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -16,6 +16,9 @@ use coset::cwt::ClaimsSetBuilder;
 use coset::iana::{Algorithm, CwtClaimName};
 use coset::{AsCborValue, CoseKey, CoseKeyBuilder, CoseMac0Builder, HeaderBuilder};
 
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+
 use super::*;
 
 fn example_key() -> CoseKey {
@@ -254,6 +257,8 @@ fn test_sign_verify() -> Result<(), AccessTokenError<<FakeCrypto as CoseCipherCo
         Some(unprotected_header.clone()),
         Some(protected_header.clone()),
     )?;
+
+    #[cfg(feature = "std")]
     println!("{:x?}", &signed);
     let (unprotected, protected) =
         get_token_headers(&signed).ok_or(AccessTokenError::UnknownCoseStructure)?;


### PR DESCRIPTION
This PR resolves #2. There are still a couple of issue before it can be merged, though:

- [X] The example for `cbor_map_vec!` currently fails as the macro is private
- [x] In `no_std` mode, tests fail due to the use of `std::error::Error` in some places/examples.