### PR TITLE
Update crate to newly released RFCs

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "../*"
+  - "/*"
+source-dir: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+This release mainly deals with the newly released RFCs and fixes `no_std` support.
+
+### Added
+
+- The `CoapOscore` profile has been added as an `AceProfile`.
+
+### Changed
+
+- The documentation has been updated to refer to the recently released RFCs instead of the now outdated internet drafts.
+
+### Fixed
+
+- The crate now properly compiles in `no_std` environments, and no tests are failing. This fixes #2.
+  (Contributed by @JKRhb in #3.)
+
 ## [0.3.1] --- 2022-08-11
 
 This release adds a derived `Deserialize` trait on `AifRestMethod`.
@@ -50,7 +67,7 @@ This release focuses on introducing [AIF] and [libdcaf]-support.
 ### Added
 
 - Support for scopes using the
-  [Authorization Information Format (AIF) for ACE](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif).
+  [Authorization Information Format (AIF) for ACE](https://www.rfc-editor.org/rfc/rfc9237.html).
   For this purpose, the following types have been added:
   - `AifEncodedScope`, representing an AIF-encoded scope (surprise)
   - `AifEncodedScopeElement`, a single element in an AIF-encoded scope
@@ -99,7 +116,9 @@ For more extensive documentation, consult the
 
 [0.3.1]: https://github.com/namib-project/dcaf-rs/compare/v0.3.0...v0.3.1
 
-[AIF]: https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.1...HEAD
+
+[AIF]: https://www.rfc-editor.org/rfc/rfc9237.html
 
 [libdcaf]: https://gitlab.informatik.uni-bremen.de/DCAF/dcaf
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@ For more extensive documentation, consult the
 
 [0.3.1]: https://github.com/namib-project/dcaf-rs/compare/v0.3.0...v0.3.1
 
-[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/namib-project/dcaf-rs/compare/v0.3.1...HEAD
 
 [AIF]: https://www.rfc-editor.org/rfc/rfc9237.html
 

--- a/src/common/cbor_map/mod.rs
+++ b/src/common/cbor_map/mod.rs
@@ -48,19 +48,17 @@
 //! [`AccessTokenRequest`]: crate::AccessTokenRequest
 
 use core::fmt::{Debug, Display, Formatter};
-
 #[cfg(feature = "std")]
 use std::any::type_name;
 
 use ciborium::de::from_reader;
 use ciborium::ser::into_writer;
-
-#[cfg(not(feature = "std"))]
-use {alloc::boxed::Box, alloc::format, alloc::vec::Vec, core::any::type_name};
-
 use ciborium::value::{Integer, Value};
 use ciborium_io::{Read, Write};
 use erased_serde::Serialize as ErasedSerialize;
+
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::format, alloc::vec::Vec, core::any::type_name};
 
 use crate::common::scope::Scope;
 use crate::error::{TryFromCborMapError, ValueIsNotIntegerError};
@@ -370,6 +368,7 @@ mod private {
 mod conversion {
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
+
     use ciborium::value::Value;
     use serde::de::{Error, Unexpected};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/common/cbor_values/mod.rs
+++ b/src/common/cbor_values/mod.rs
@@ -28,12 +28,12 @@
 
 use core::fmt::{Debug, Display, Formatter};
 use core::ops::Deref;
-use strum_macros::IntoStaticStr;
 
 #[cfg(not(feature = "std"))]
 use {alloc::boxed::Box, alloc::format, alloc::vec, alloc::vec::Vec};
 
 use coset::{CoseEncrypt0, CoseKey};
+use strum_macros::IntoStaticStr;
 
 /// A type intended to be used as a CBOR bytestring, represented as a vector of bytes.
 pub type ByteString = Vec<u8>;
@@ -51,7 +51,7 @@ where
 /// [RFC 8747, section 3.1](https://datatracker.ietf.org/doc/html/rfc8747#section-3.1).
 ///
 /// Can either be a COSE key, an encrypted COSE key, or simply a key ID.
-/// As described in [`draft-ietf-ace-oauth-params-16`](https://datatracker.ietf.org/doc/html/draft-ietf-ace-oauth-params-16),
+/// As described in [RFC 9201](https://www.rfc-editor.org/rfc/rfc9201),
 /// PoP keys are used for the `req_cnf` parameter in [`AccessTokenRequest`](crate::AccessTokenRequest),
 /// as well as for the `cnf` and `rs_cnf` parameters in [`AccessTokenResponse`](crate::AccessTokenResponse).
 ///
@@ -141,13 +141,13 @@ where
 
 /// Contains various `From`, `TryFrom` and other conversion methods for types of the parent module.
 mod conversion {
-    use crate::common::cbor_map::ToCborMap;
     use ciborium::value::Value;
     use coset::{AsCborValue, CoseEncrypt0, CoseKey};
     use erased_serde::Serialize as ErasedSerialize;
-    use serde::de::Error;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde::de::Error;
 
+    use crate::common::cbor_map::ToCborMap;
     use crate::error::{TryFromCborMapError, WrongSourceTypeError};
 
     use super::*;

--- a/src/common/cbor_values/mod.rs
+++ b/src/common/cbor_values/mod.rs
@@ -144,8 +144,8 @@ mod conversion {
     use ciborium::value::Value;
     use coset::{AsCborValue, CoseEncrypt0, CoseKey};
     use erased_serde::Serialize as ErasedSerialize;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde::de::Error;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     use crate::common::cbor_map::ToCborMap;
     use crate::error::{TryFromCborMapError, WrongSourceTypeError};

--- a/src/common/constants.rs
+++ b/src/common/constants.rs
@@ -168,10 +168,9 @@ pub mod cbor_abbreviations {
         /// [RFC 9202](https://www.rfc-editor.org/rfc/rfc9202).
         pub const COAP_DTLS: i32 = 1;
 
-        // The below is commented out because no CBOR value has been set in the specification yet.
-        // /// OSCORE profile specified in
-        // /// [`draft-ietf-ace-oscore-profile`](https://www.ietf.org/archive/id/draft-ietf-ace-oscore-profile-19.txt).
-        // // pub const COAP_OSCORE: i32;
+        /// OSCORE profile specified in
+        /// [RFC 9203](https://www.rfc-editor.org/rfc/rfc9203).
+        pub const COAP_OSCORE: i32 = 2;
     }
 
     /// Constants for CBOR abbreviations in error codes,

--- a/src/common/constants.rs
+++ b/src/common/constants.rs
@@ -9,114 +9,114 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
 
-//! Contains various constants defined in the standards and drafts related to ACE-OAuth.
+//! Contains various constants defined in the standards related to ACE-OAuth.
 //!
 //! # Sources
-//! - [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html)
-//! - [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html)
-//! - [`draft-ietf-ace-oauth-params-16`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-params-16.html)
-//! - [`draft-ietf-ace-oscore-profile`](https://www.ietf.org/archive/id/draft-ietf-ace-oscore-profile-19.txt)
-//! - [`draft-ietf-ace-dtls-authorize`](https://www.ietf.org/archive/id/draft-ietf-ace-dtls-authorize-18.html)
+//! - [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200)
+//! - [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749)
+//! - [RFC 9201](https://www.rfc-editor.org/rfc/rfc9201)
+//! - [RFC 9202](https://www.rfc-editor.org/rfc/rfc9202)
+//! - [RFC 9203](https://www.rfc-editor.org/rfc/rfc9203)
 
 /// Constants which abbreviate string values as integers in CBOR.
 pub mod cbor_abbreviations {
     /// Constants for CBOR map keys in AS Request Creation Hints,
-    /// as specified in [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html), Figure 2.
+    /// as specified in [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200), Table 1.
     pub mod creation_hint {
-        /// See section 5.3 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+        /// See section 5.3 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
         pub const AS: u8 = 1;
 
-        /// See section 5.3 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+        /// See section 5.3 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
         pub const KID: u8 = 2;
 
-        /// See section 5.3 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+        /// See section 5.3 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
         pub const AUDIENCE: u8 = 5;
 
-        /// See section 5.3 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+        /// See section 5.3 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
         pub const SCOPE: u8 = 9;
 
-        /// See section 5.3 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+        /// See section 5.3 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
         pub const CNONCE: u8 = 39;
     }
 
     /// Constants for CBOR map keys in token requests and responses,
-    /// as specified in [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html), Figure 12
-    /// and `draft-ietf-ace-oauth-params`, Figure 5.
+    /// as specified in [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200), Table 5
+    /// and [RFC 9201](https://www.rfc-editor.org/rfc/rfc9201.html), Table 1.
     pub mod token {
-        /// See section 5.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const ACCESS_TOKEN: u8 = 1;
 
-        /// See section 5.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const EXPIRES_IN: u8 = 2;
 
-        /// See section 3.1 of [`draft-ietf-ace-oauth-params-16`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-params-16.html).
+        /// See section 3.1 of [RFC 9201](https://www.rfc-editor.org/rfc/rfc9201).
         pub const REQ_CNF: u8 = 4;
 
-        /// See section 2.1 of [RFC 8693](https://www.rfc-editor.org/rfc/rfc8693.html).
+        /// See section 2.1 of [RFC 8693](https://www.rfc-editor.org/rfc/rfc8693).
         pub const AUDIENCE: u8 = 5;
 
-        /// See section 3.2 of [`draft-ietf-ace-oauth-params-16`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-params-16.html).
+        /// See section 3.2 of [RFC 9201](https://www.rfc-editor.org/rfc/rfc9201).
         pub const CNF: u8 = 8;
 
-        /// See section 4.4.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html)
-        /// and section 5.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 4.4.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749)
+        /// and section 5.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const SCOPE: u8 = 9;
 
-        /// See section 2.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 2.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const CLIENT_ID: u8 = 24;
 
-        /// See section 2.3.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 2.3.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const CLIENT_SECRET: u8 = 25;
 
-        /// See section 3.1.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 3.1.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const RESPONSE_TYPE: u8 = 26;
 
-        /// See section 3.1.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 3.1.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const REDIRECT_URI: u8 = 27;
 
-        /// See section 4.1.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 4.1.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const STATE: u8 = 28;
 
-        /// See section 4.1.3 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 4.1.3 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const CODE: u8 = 29;
 
-        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const ERROR: u8 = 30;
 
-        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const ERROR_DESCRIPTION: u8 = 31;
 
-        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const ERROR_URI: u8 = 32;
 
-        /// See section 4.4.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 4.4.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const GRANT_TYPE: u8 = 33;
 
-        /// See section 5.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const TOKEN_TYPE: u8 = 34;
 
-        /// See section 4.3.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 4.3.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const USERNAME: u8 = 35;
 
-        /// See section 4.3.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 4.3.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const PASSWORD: u8 = 36;
 
-        /// See section 5.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.1 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const REFRESH_TOKEN: u8 = 37;
 
-        /// See section 5.8.4.3 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+        /// See section 5.8.4.3 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
         pub const ACE_PROFILE: u8 = 38;
 
-        /// See section 5.8.4.4 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+        /// See section 5.8.4.4 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
         pub const CNONCE: u8 = 39;
 
-        /// See section 3.2 of [`draft-ietf-ace-oauth-params-16`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-params-16.html).
+        /// See section 3.2 of [RFC 9201](https://www.rfc-editor.org/rfc/rfc9201).
         pub const RS_CNF: u8 = 41;
     }
 
     /// Constants for CBOR map keys in token introspections,
-    /// as specified in [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html), Figure 16
-    /// and [RFC 8392](https://www.rfc-editor.org/rfc/rfc8392.html).
+    /// as specified in [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200), Table 6
+    /// and [RFC 8392](https://www.rfc-editor.org/rfc/rfc8392).
     ///
     /// Some of these constants are also used by libdcaf for additional fields which are required
     /// according to [DCAF](https://gitlab.informatik.uni-bremen.de/DCAF/dcaf/).
@@ -124,52 +124,48 @@ pub mod cbor_abbreviations {
     /// **NOTE: This is currently incomplete!**
     /// Only libdcaf-required parameters are in here for now.
     pub mod introspection {
-        /// See [section 3.1.1 of RFC 8392](https://www.rfc-editor.org/rfc/rfc8392.html#section-3.1.1).
+        /// See [section 3.1.1 of RFC 8392](https://www.rfc-editor.org/rfc/rfc8392#section-3.1.1).
         pub const ISSUER: u8 = 1;
 
-        /// See [section 3.1.6 of RFC 8392](https://www.rfc-editor.org/rfc/rfc8392.html#section-3.1.6).
+        /// See [section 3.1.6 of RFC 8392](https://www.rfc-editor.org/rfc/rfc8392#section-3.1.6).
         pub const ISSUED_AT: u8 = 6;
     }
 
     /// Constants for CBOR abbreviations in grant types,
-    /// as specified in [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html), Figure 11.
+    /// as specified in [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200), Table 4.
     pub mod grant_types {
-        /// See section 4.3.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 4.3.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const PASSWORD: i32 = 0;
 
-        /// See section 4.1.3 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 4.1.3 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const AUTHORIZATION_CODE: i32 = 1;
 
-        /// See section 4.4.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 4.4.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const CLIENT_CREDENTIALS: i32 = 2;
 
-        /// See section 6 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 6 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const REFRESH_TOKEN: i32 = 3;
     }
 
     /// Constants for CBOR abbreviations in token types,
-    /// as specified in [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html), Section 8.7.
+    /// as specified in [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200), Section 8.7.
     pub mod token_types {
         /// Bearer token type, as specified in
-        /// [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const BEARER: i32 = 1;
 
         /// Proof-of-possession token type, as specified in
-        /// [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+        /// [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
         pub const POP: i32 = 2;
     }
 
     /// Constants for CBOR abbreviations in token types, as specified in:
-    /// - `draft-ietf-ace-oauth-authz`, section 8.8.
-    /// - [`draft-ietf-ace-oscore-profile`](https://www.ietf.org/archive/id/draft-ietf-ace-oscore-profile-19.txt),
-    ///   section 9.1.
-    /// - [`draft-ietf-ace-dtls-authorize`](https://www.ietf.org/archive/id/draft-ietf-ace-dtls-authorize-18.html),
-    ///   section 9.
+    /// - [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200.html), section 8.8.
+    /// - [RFC 9202](https://www.rfc-editor.org/rfc/rfc9202), section 9.
+    /// - [RFC 9203](https://www.rfc-editor.org/rfc/rfc9203), section 9.1.
     pub mod ace_profile {
         /// DTLS profile specified in
-        /// [`draft-ietf-ace-oscore-profile`](https://www.ietf.org/archive/id/draft-ietf-ace-oscore-profile-19.txt).
-        ///
-        /// **Note: The actual value is still TBD, this is just what's suggested in the draft above.**
+        /// [RFC 9202](https://www.rfc-editor.org/rfc/rfc9202).
         pub const COAP_DTLS: i32 = 1;
 
         // The below is commented out because no CBOR value has been set in the specification yet.
@@ -179,30 +175,30 @@ pub mod cbor_abbreviations {
     }
 
     /// Constants for CBOR abbreviations in error codes,
-    /// as specified in [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html), Figure 10.
+    /// as specified in [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200), Table 3.
     pub mod error {
-        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const INVALID_REQUEST: i32 = 1;
 
-        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const INVALID_CLIENT: i32 = 2;
 
-        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const INVALID_GRANT: i32 = 3;
 
-        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const UNAUTHORIZED_CLIENT: i32 = 4;
 
-        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const UNSUPPORTED_GRANT_TYPE: i32 = 5;
 
-        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+        /// See section 5.2 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
         pub const INVALID_SCOPE: i32 = 6;
 
-        /// See section 5.8.3 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+        /// See section 5.8.3 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
         pub const UNSUPPORTED_POP_KEY: i32 = 7;
 
-        /// See section 5.8.3 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+        /// See section 5.8.3 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
         pub const INCOMPATIBLE_ACE_PROFILES: i32 = 8;
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -12,8 +12,7 @@
 //! Common types used throughout the crate.
 //!
 //! # Layout
-//! - [`constants`] contains various constants defined in the standards and drafts related to
-//!   ACE-OAuth.
+//! - [`constants`] contains various constants defined in the standards related to ACE-OAuth.
 //! - [`cbor_map`] contains the [`ToCborMap`](crate::common::cbor_map::ToCborMap) trait with which
 //!   data types from this crate can be (de)serialized.
 //! - [`cbor_values`] contains various helper values for CBOR structures.

--- a/src/common/scope/mod.rs
+++ b/src/common/scope/mod.rs
@@ -547,8 +547,8 @@ pub enum Scope {
 /// models which are represented as CBOR maps.
 mod conversion {
     use ciborium::value::{Integer, Value};
-    use serde::{Deserializer, Serializer};
     use serde::de::Error;
+    use serde::{Deserializer, Serializer};
 
     use crate::error::{
         InvalidAifEncodedScopeError, InvalidBinaryEncodedScopeError, InvalidTextEncodedScopeError,

--- a/src/common/scope/mod.rs
+++ b/src/common/scope/mod.rs
@@ -92,10 +92,10 @@
 //!
 //! # Sources
 //! For the original OAuth 2.0 standard, scopes are defined in
-//! [RFC 6749, section 1.3](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.3),
+//! [RFC 6749, section 1.3](https://www.rfc-editor.org/rfc/rfc6749#section-1.3),
 //! while for ACE-OAuth, they're specified in
-//! [`draft-ietf-ace-oauth-authz`, section 5.8.1](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8.1-2.4).
-//! AIF is defined in [`draft-ietf-ace-aif`](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-3).
+//! [RFC 9200, section 5.8.1](https://www.rfc-editor.org/rfc/rfc9200#section-5.8.1-2.4).
+//! AIF is defined in [RFC 9237](https://www.rfc-editor.org/rfc/rfc9237).
 
 #[cfg(not(feature = "std"))]
 use {alloc::string::String, alloc::string::ToString, alloc::vec, alloc::vec::Vec};
@@ -139,7 +139,7 @@ mod tests;
 pub type AifRestMethodSet = BitFlags<AifRestMethod>;
 
 /// A scope encoded as a space-delimited list of strings, as defined in
-/// [RFC 6749, section 1.3](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.3).
+/// [RFC 6749, section 1.3](https://www.rfc-editor.org/rfc/rfc6749#section-1.3).
 ///
 /// Note that the syntax specified in the RFC has to be followed:
 /// ```text
@@ -217,20 +217,20 @@ pub struct BinaryEncodedScope(ByteString);
 ///
 /// Note that in addition to the usual CoAP and HTTP REST methods
 /// (see "Relevant Documents" below),
-/// methods for [Dynamic Resource Creation](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.3)
+/// methods for [Dynamic Resource Creation](https://www.rfc-editor.org/rfc/rfc9237#section-2.3)
 /// are also provided.
 ///
 /// This uses the [`enumflags2`] crate to make it easy to work with resulting bitmasks.
 ///
 /// # Relevant Documents
 /// - Definition of `REST-method-set` data model for use in AIF:
-///   Figure 4 of [`draft-ietf-ace-aif`, section 3](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-3)
+///   Figure 4 of [RFC 9237](https://www.rfc-editor.org/rfc/rfc9237#figure-4)
 /// - Specification of HTTP methods GET, POST, PUT, DELETE: [RFC 7231, section 4.3](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3)
 /// - Specification of HTTP PATCH method: [RFC 5789](https://datatracker.ietf.org/doc/html/rfc5789)
 /// - Specification of CoAP methods GET, POST, PUT, DELETE: [RFC 7252, section 5.8](https://datatracker.ietf.org/doc/html/rfc7252#section-5.8),
 /// - Specification of CoAP methods FETCH, PATCH, AND iPATCH: [RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132)
 /// - Specification of Dynamic CoAP methods:
-///   Figure 4 of [`draft-ietf-ace-aif`, section 2.3](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.3)
+///   [RFC 9237, section 2.3](https://www.rfc-editor.org/rfc/rfc9237#section-2.3)
 ///
 /// # Example
 /// You can easily combine multiple fields using the bitwise OR operator, as well as
@@ -293,38 +293,38 @@ pub enum AifRestMethod {
 
     /// GET method as specified in [RFC 7252, section 5.8.1 (CoAP)](https://datatracker.ietf.org/doc/html/rfc7252#section-5.8.1)
     /// and [RFC 7231, section 4.3.1 (HTTP)](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.1),
-    /// intended for use in [Dynamic Resource Creation](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.3).
+    /// intended for use in [Dynamic Resource Creation](https://www.rfc-editor.org/rfc/rfc9237#section-2.3).
     DynamicGet = u64::pow(2, 32),
 
     /// POST method as specified in [RFC 7252, section 5.8.2 (CoAP)](https://datatracker.ietf.org/doc/html/rfc7252#section-5.8.2)
     /// and [RFC 7231, section 4.3.3 (HTTP)](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.3),
-    /// intended for use in [Dynamic Resource Creation](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.3).
+    /// intended for use in [Dynamic Resource Creation](https://www.rfc-editor.org/rfc/rfc9237#section-2.3).
     DynamicPost = u64::pow(2, 33),
 
     /// PUT method as specified in [RFC 7252, section 5.8.3 (CoAP)](https://datatracker.ietf.org/doc/html/rfc7252#section-5.8.3)
     /// and [RFC 7231, section 4.3.4 (HTTP)](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.4),
-    /// intended for use in [Dynamic Resource Creation](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.3).
+    /// intended for use in [Dynamic Resource Creation](https://www.rfc-editor.org/rfc/rfc9237#section-2.3).
     DynamicPut = u64::pow(2, 34),
 
     /// DELETE method as specified in [RFC 7252, section 5.8.4 (CoAP)](https://datatracker.ietf.org/doc/html/rfc7252#section-5.8.4)
     /// and [RFC 7231, section 4.3.5 (HTTP)](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.5),
-    /// intended for use in [Dynamic Resource Creation](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.3).
+    /// intended for use in [Dynamic Resource Creation](https://www.rfc-editor.org/rfc/rfc9237#section-2.3).
     DynamicDelete = u64::pow(2, 35),
 
     /// FETCH method as specified in [RFC 8132, section 2 (CoAP)](https://datatracker.ietf.org/doc/html/rfc8132#section-2),
-    /// intended for use in [Dynamic Resource Creation](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.3).
+    /// intended for use in [Dynamic Resource Creation](https://www.rfc-editor.org/rfc/rfc9237#section-2.3).
     ///
     /// Not available for HTTP.
     DynamicFetch = u64::pow(2, 36),
 
     /// PATCH method as specified in [RFC 8132, section 3 (CoAP)](https://datatracker.ietf.org/doc/html/rfc8132#section-3),
-    /// intended for use in [Dynamic Resource Creation](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.3).
+    /// intended for use in [Dynamic Resource Creation](https://www.rfc-editor.org/rfc/rfc9237#section-2.3).
     ///
     /// Not available for HTTP.
     DynamicPatch = u64::pow(2, 37),
 
     /// iPATCH method as specified in [RFC 8132, section 3 (CoAP)](https://datatracker.ietf.org/doc/html/rfc8132#section-3),
-    /// intended for use in [Dynamic Resource Creation](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.3).
+    /// intended for use in [Dynamic Resource Creation](https://www.rfc-editor.org/rfc/rfc9237#section-2.3).
     ///
     /// Not available for HTTP.
     DynamicIPatch = u64::pow(2, 38),
@@ -341,7 +341,7 @@ pub struct AifEncodedScopeElement {
     /// Identifier for the object of this scope element,
     /// given as a URI of a resource on a CoAP server.
     ///
-    /// Refer to [section 2 of `draft-ietf-ace-aif`](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2)
+    /// Refer to [section 2 of RFC 9237](https://www.rfc-editor.org/rfc/rfc9237#section-2)
     /// for specification details.
     pub path: String,
 
@@ -349,16 +349,16 @@ pub struct AifEncodedScopeElement {
     /// of this scope element, given as a set of REST (CoAP or HTTP) methods.
     ///
     /// More specifically, this is a bitmask---see [`AifRestMethod`] for further explanation.
-    /// Refer to [section 2 of `draft-ietf-ace-aif`](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2)
+    /// Refer to [section 2 of RFC 9237](https://www.rfc-editor.org/rfc/rfc9237#section-2)
     /// for specification details.
     pub permissions: BitFlags<AifRestMethod>,
 }
 
 /// A scope encoded using the
-/// [Authorization Information Format (AIF) for ACE](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif).
+/// [Authorization Information Format (AIF) for ACE](https://www.rfc-editor.org/rfc/rfc9237).
 ///
 /// More specifically, this uses the specific instantiation of AIF intended for REST resources
-/// which are identified by URI paths, as described in [`draft-ietf-ace-aif`, section 2.1](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.1).
+/// which are identified by URI paths, as described in [RFC 9237, section 2.1](https://www.rfc-editor.org/rfc/rfc9237#section-2.1).
 /// An AIF-encoded scope consists of [`AifEncodedScopeElement`]s, each describing a URI path
 /// (the object of the scope) and a set of REST methods (the permissions of the scope).
 ///
@@ -389,7 +389,7 @@ pub struct AifEncodedScopeElement {
 /// ```json
 /// [["restricted", 17], ["unrestricted", 545460846719]]
 /// ```
-/// As specified in [`draft-ietf-ace-aif`, section 3](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-3),
+/// As specified in [RFC 9237, section 3](https://www.rfc-editor.org/rfc/rfc9237#section-3),
 /// `GET` to `iPATCH` are encoded from 2<sup>0</sup> to 2<sup>6</sup>, while the dynamic variants
 /// go from 2<sup>32</sup> to 2<sup>38</sup>. This is why in `restricted`, the number equals
 /// 17 (2<sup>0</sup> + 2<sup>4</sup>), and in `unrestricted` equals the sum of all these numbers.
@@ -399,7 +399,7 @@ pub struct AifEncodedScopeElement {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize)]
 pub struct AifEncodedScope(Vec<AifEncodedScopeElement>);
 
-/// A scope encoded using the [Authorization Information Format (AIF) for ACE](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif)
+/// A scope encoded using the [Authorization Information Format (AIF) for ACE](https://www.rfc-editor.org/rfc/rfc9237)
 /// as in [`AifEncodedScope`], but only consisting of a single [`AifEncodedScopeElement`]
 /// instead of an array of them.
 ///
@@ -442,7 +442,7 @@ pub struct AifEncodedScope(Vec<AifEncodedScopeElement>);
 pub struct LibdcafEncodedScope(AifEncodedScopeElement);
 
 /// Scope of an access token as specified in
-/// [`draft-ietf-ace-oauth-authz`, section 5.8.1](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8.1-2.4).
+/// [RFC 9200, section 5.8.1](https://www.rfc-editor.org/rfc/rfc9200#section-5.8.1-2.4).
 ///
 /// May be used both for [AccessTokenRequest](crate::AccessTokenRequest)s and
 /// [AccessTokenResponse](crate::AccessTokenResponse)s.
@@ -470,7 +470,7 @@ pub struct LibdcafEncodedScope(AifEncodedScopeElement);
 #[derive(Debug, PartialEq, Eq, Clone, Hash, IntoStaticStr)]
 pub enum Scope {
     /// Scope encoded using Text, as specified in
-    /// [RFC 6749, section 1.3](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.3).
+    /// [RFC 6749, section 1.3](https://www.rfc-editor.org/rfc/rfc6749#section-1.3).
     ///
     /// For details, see the documentation of [`TextEncodedScope`].
     ///
@@ -505,7 +505,7 @@ pub enum Scope {
     /// ```
     BinaryEncoded(BinaryEncodedScope),
 
-    /// Scope encoded using the [Authorization Information Format (AIF) for ACE](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif).
+    /// Scope encoded using the [Authorization Information Format (AIF) for ACE](https://www.rfc-editor.org/rfc/rfc9237).
     ///
     /// For details, see the documentation of [`AifEncodedScope`].
     ///
@@ -547,8 +547,8 @@ pub enum Scope {
 /// models which are represented as CBOR maps.
 mod conversion {
     use ciborium::value::{Integer, Value};
-    use serde::de::Error;
     use serde::{Deserializer, Serializer};
+    use serde::de::Error;
 
     use crate::error::{
         InvalidAifEncodedScopeError, InvalidBinaryEncodedScopeError, InvalidTextEncodedScopeError,
@@ -706,7 +706,7 @@ mod conversion {
         /// Creates a new [`AifEncodedScopeElement`] over the given `path` and `permissions`.
         ///
         /// # Example
-        /// Let's take the example given in Table 2 of [the draft](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-2.3):
+        /// Let's take the example given in Table 2 of [the RFC](https://www.rfc-editor.org/rfc/rfc9237#table-2):
         /// ```text
         ///   +================+===================================+
         ///   | URI-local-part | Permission Set                    |
@@ -739,12 +739,12 @@ mod conversion {
         /// Tries to create a new [`AifEncodedScopeElement`] from the given `path` and `permissions`.
         ///
         /// `permissions` must be a valid bitmask of REST methods, as defined in
-        /// [section 3 of `draft-ietf-ace-aif`](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-3).
+        /// [section 3 of RFC 9237](https://www.rfc-editor.org/rfc/rfc9237#section-3).
         ///
         /// # Errors
         /// If the given `permissions` do not correspond to a valid set of [`AifRestMethod`]s
         /// as defined in
-        /// [section 3 of `draft-ietf-ace-aif`](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-3).
+        /// [section 3 of RFC 9237](https://www.rfc-editor.org/rfc/rfc9237#section-3).
         ///
         /// # Example
         /// For example, say we want to encode `["/a/led", 5]`, where the 5 corresponds to
@@ -893,7 +893,7 @@ mod conversion {
         /// Tries to create a new libdcaf-encoded scope from the given `path` and `permissions`.
         ///
         /// The given `permissions` must be a valid bitmask of the allowed REST methods,
-        /// as defined in [section 3 of `draft-ietf-ace-aif`](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif#section-3).
+        /// as defined in [section 3 of RFC 9237](https://www.rfc-editor.org/rfc/rfc9237#section-3).
         ///
         /// # Errors
         /// Refer to [`AifEncodedScopeElement::try_from_bits`].

--- a/src/common/scope/tests.rs
+++ b/src/common/scope/tests.rs
@@ -148,11 +148,11 @@ mod aif {
 
     use ciborium::de::from_reader;
     use ciborium::ser::into_writer;
-    use enumflags2::{make_bitflags, BitFlags};
+    use enumflags2::{BitFlags, make_bitflags};
 
+    use crate::{AifEncodedScope, Scope};
     use crate::common::scope::{AifEncodedScopeElement, AifRestMethod, AifRestMethodSet};
     use crate::error::InvalidAifEncodedScopeError;
-    use crate::{AifEncodedScope, Scope};
 
     pub(crate) fn example_elements() -> (
         AifEncodedScopeElement,
@@ -256,7 +256,7 @@ mod aif {
 
     #[test]
     fn test_scope_encoding() -> Result<(), String> {
-        // This tests the encoding of the scope using the example given in Figure 5 of the AIF draft.
+        // This tests the encoding of the scope using the example given in Figure 5 of the AIF RFC.
         let cbor = hex::decode("8382672F732F74656D700182662F612F6C65640582652F64746C7302")
             .map_err(|x| x.to_string())?;
         let expected: Scope = AifEncodedScope::from(vec![
@@ -279,8 +279,8 @@ mod libdcaf {
 
     use ciborium::de::from_reader;
 
-    use crate::error::InvalidAifEncodedScopeError;
     use crate::{LibdcafEncodedScope, Scope};
+    use crate::error::InvalidAifEncodedScopeError;
 
     use super::aif::example_elements;
 

--- a/src/common/scope/tests.rs
+++ b/src/common/scope/tests.rs
@@ -148,11 +148,11 @@ mod aif {
 
     use ciborium::de::from_reader;
     use ciborium::ser::into_writer;
-    use enumflags2::{BitFlags, make_bitflags};
+    use enumflags2::{make_bitflags, BitFlags};
 
-    use crate::{AifEncodedScope, Scope};
     use crate::common::scope::{AifEncodedScopeElement, AifRestMethod, AifRestMethodSet};
     use crate::error::InvalidAifEncodedScopeError;
+    use crate::{AifEncodedScope, Scope};
 
     pub(crate) fn example_elements() -> (
         AifEncodedScopeElement,
@@ -279,8 +279,8 @@ mod libdcaf {
 
     use ciborium::de::from_reader;
 
-    use crate::{LibdcafEncodedScope, Scope};
     use crate::error::InvalidAifEncodedScopeError;
+    use crate::{LibdcafEncodedScope, Scope};
 
     use super::aif::example_elements;
 
@@ -321,7 +321,7 @@ mod libdcaf {
     fn test_scope_element_empty() {
         // Emptiness isn't allowed here.
         let serialized = vec![0x80]; // empty CBOR array
-        // That means that this *must not* resolve to a libdcaf scope
+                                     // That means that this *must not* resolve to a libdcaf scope
         assert!(from_reader::<Scope, &[u8]>(serialized.as_slice())
             .ok()
             .map(LibdcafEncodedScope::try_from)

--- a/src/common/scope/tests.rs
+++ b/src/common/scope/tests.rs
@@ -321,7 +321,7 @@ mod libdcaf {
     fn test_scope_element_empty() {
         // Emptiness isn't allowed here.
         let serialized = vec![0x80]; // empty CBOR array
-                                     // That means that this *must not* resolve to a libdcaf scope
+        // That means that this *must not* resolve to a libdcaf scope
         assert!(from_reader::<Scope, &[u8]>(serialized.as_slice())
             .ok()
             .map(LibdcafEncodedScope::try_from)

--- a/src/endpoints/creation_hint/mod.rs
+++ b/src/endpoints/creation_hint/mod.rs
@@ -11,9 +11,11 @@
 
 //! Contains the data model for
 //! [Authorization Server Request Creation Hints](self::AuthServerRequestCreationHint),
-//! as described in [`draft-ietf-ace-oauth-authz-46`, section 5.3](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#name-as-request-creation-hints).
+//! as described in [RFC 9200, section 5.3](https://www.rfc-editor.org/rfc/rfc9200#name-as-request-creation-hints).
 //!
 //! See the documentation of [`AuthServerRequestCreationHint`] for details and an example.
+
+use alloc::string::String;
 
 use crate::common::cbor_values::ByteString;
 use crate::Scope;
@@ -27,13 +29,13 @@ mod tests;
 /// This is sent by an RS as a response to an Unauthorized Resource Request Message
 /// to help the sender of the Unauthorized Resource Request Message acquire a valid access token.
 ///
-/// For more information, see [section 5.3 of `draft-ietf-ace-oauth-authz`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.3).
+/// For more information, see [section 5.3 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.3).
 ///
 /// Use the [`AuthServerRequestCreationHintBuilder`] (which you can access using the
 /// [`builder()`](AuthServerRequestCreationHint::builder) method) to create an instance of this struct.
 ///
 /// # Example
-/// Figure 3 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#figure-3)
+/// Figure 3 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#figure-3)
 /// gives us an example of a Request Creation Hint payload, given in CBOR diagnostic notation[^cbor]:
 /// ```text
 /// {
@@ -96,7 +98,7 @@ pub struct AuthServerRequestCreationHint {
     /// See the documentation of [`Scope`] for details.
     pub scope: Option<Scope>,
 
-    /// A client nonce as described in [section 5.3.1 of `draft-ietf-ace-oauth-authz`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.3.1).
+    /// A client nonce as described in [section 5.3.1 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.3.1).
     pub client_nonce: Option<Vec<u8>>,
 }
 
@@ -136,6 +138,7 @@ mod conversion {
     use ciborium::value::Value;
     use erased_serde::Serialize as ErasedSerialize;
 
+    use crate::common::cbor_map::{cbor_map_vec, decode_scope, ToCborMap};
     use crate::common::constants::cbor_abbreviations::creation_hint;
     use crate::error::TryFromCborMapError;
 

--- a/src/endpoints/creation_hint/mod.rs
+++ b/src/endpoints/creation_hint/mod.rs
@@ -15,8 +15,6 @@
 //!
 //! See the documentation of [`AuthServerRequestCreationHint`] for details and an example.
 
-use alloc::string::String;
-
 use crate::common::cbor_values::ByteString;
 use crate::Scope;
 
@@ -130,8 +128,6 @@ mod builder {
 /// another part is implementing the [`ToCborMap`](crate::ToCborMap) type for the
 /// models which are represented as CBOR maps.
 mod conversion {
-    use crate::common::cbor_map::{cbor_map_vec, decode_scope, ToCborMap};
-
     #[cfg(not(feature = "std"))]
     use alloc::boxed::Box;
 

--- a/src/endpoints/creation_hint/tests.rs
+++ b/src/endpoints/creation_hint/tests.rs
@@ -12,15 +12,15 @@
 #[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 
-use enumflags2::{make_bitflags, BitFlags};
+use enumflags2::{BitFlags, make_bitflags};
 
+use crate::{AifEncodedScope, BinaryEncodedScope, LibdcafEncodedScope};
 use crate::common::scope::{AifRestMethod, TextEncodedScope};
 use crate::common::test_helper::expect_ser_de;
-use crate::{AifEncodedScope, BinaryEncodedScope, LibdcafEncodedScope};
 
 use super::*;
 
-/// Example data taken from draft-ietf-ace-oauth-authz-46, Figure 3 and 4.
+/// Example data taken from RFC 9200, Figure 2 and 3.
 #[test]
 fn test_creation_hint_text_scope() -> Result<(), String> {
     let hint = AuthServerRequestCreationHintBuilder::default()

--- a/src/endpoints/creation_hint/tests.rs
+++ b/src/endpoints/creation_hint/tests.rs
@@ -12,11 +12,11 @@
 #[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 
-use enumflags2::{BitFlags, make_bitflags};
+use enumflags2::{make_bitflags, BitFlags};
 
-use crate::{AifEncodedScope, BinaryEncodedScope, LibdcafEncodedScope};
 use crate::common::scope::{AifRestMethod, TextEncodedScope};
 use crate::common::test_helper::expect_ser_de;
+use crate::{AifEncodedScope, BinaryEncodedScope, LibdcafEncodedScope};
 
 use super::*;
 

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -12,7 +12,7 @@
 //! Contains CBOR-serializable data types for the endpoints of ACE-OAuth.
 //!
 //! These endpoints are described in section 5 of
-//! [`draft-ietf-ace-oauth-authz`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+//! [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
 //!
 //! Support for the introspection endpoint is planned.
 //!

--- a/src/endpoints/token_req/mod.rs
+++ b/src/endpoints/token_req/mod.rs
@@ -10,7 +10,7 @@
  */
 
 //! Contains the data models for structures related to access token requests and responses,
-//! as described in [`draft-ietf-ace-oauth-authz-46`, section 5.8](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8).
+//! as described in [RFC 9200, section 5.8](https://www.rfc-editor.org/rfc/rfc9200#section-5.8).
 //!
 //! The most important members of this module are [`AccessTokenRequest`], [`AccessTokenResponse`],
 //! and [`ErrorResponse`]. Look at their documentation for usage examples.
@@ -27,7 +27,7 @@ use {alloc::boxed::Box, alloc::string::String, alloc::vec::Vec};
 mod tests;
 
 /// Type of the resource owner's authorization used by the client to obtain an access token.
-/// For more information, see [section 1.3 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+/// For more information, see [section 1.3 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
 ///
 /// Grant types are used in the [`AccessTokenRequest`].
 ///
@@ -44,7 +44,7 @@ mod tests;
 /// # Ok::<(), AccessTokenRequestBuilderError>(())
 /// ```
 /// It's also possible to use your own value for a custom grant type, as defined in
-/// [section 8.5 of `draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-8.5):
+/// [section 8.5 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-8.5):
 /// ```
 /// # use dcaf::{AccessTokenRequest, GrantType};
 /// # use dcaf::endpoints::token_req::AccessTokenRequestBuilderError;
@@ -64,13 +64,13 @@ pub enum GrantType {
     /// Note that the authorization server should take special care when
     /// enabling this grant type and only allow it when other flows are not viable.
     ///
-    /// See [section 4.3 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-4.3)
+    /// See [section 4.3 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-4.3)
     /// for details.
     Password,
 
     /// Redirection-based flow optimized for confidential clients.
     ///
-    /// See [section 4.1 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1)
+    /// See [section 4.1 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-4.1)
     /// for details.
     AuthorizationCode,
 
@@ -78,7 +78,7 @@ pub enum GrantType {
     ///
     /// Must only be used for confidential clients.
     ///
-    /// See [section 4.4 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-4.4)
+    /// See [section 4.4 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
     /// for details.
     ClientCredentials,
 
@@ -87,25 +87,25 @@ pub enum GrantType {
     /// When using this, it's necessary that [`refresh_token`](AccessTokenResponse::refresh_token)
     /// is specified in the [`AccessTokenResponse`].
     ///
-    /// See [section 6 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-6)
+    /// See [section 6 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-6)
     /// for details.
     RefreshToken,
 
     /// Another authorization grant not listed here.
     ///
-    /// See [section 8.5 of `draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-8.5)
+    /// See [section 8.5 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-8.5)
     /// for corresponding IANA registries.
     Other(i32),
 }
 
-/// Request for an access token, sent from the client, as defined in [section 5.8.1 of
-/// `draft-ietf-ace-oauth-authz`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8.1).
+/// Request for an access token, sent from the client, as defined in
+/// [section 5.8.1 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.8.1).
 ///
 /// Use the [`AccessTokenRequestBuilder`] (which you can access using the
 /// [`AccessTokenRequest::builder()`] method) to create an instance of this struct.
 ///
 /// # Example
-/// Figure 5 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#figure-5)
+/// Figure 5 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#figure-4)
 /// gives us an example of an access token request, given in CBOR diagnostic notation[^cbor]:
 /// ```text
 /// {
@@ -146,7 +146,7 @@ pub struct AccessTokenRequest {
     // TODO: Certain grant types have certain required fields. These should be verified in the
     //       builder's `validate` method (only if the grant type is given! Otherwise, check spec.)
     /// The client identifier as described in section 2.2 of
-    /// [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+    /// [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
     #[builder(default)]
     pub client_id: Option<String>,
 
@@ -171,7 +171,7 @@ pub struct AccessTokenRequest {
     pub client_nonce: Option<ByteString>,
 
     /// Scope of the access request as described by section 3.3 of
-    /// [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html).
+    /// [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749).
     ///
     /// See also the documentation of [`Scope`] for details.
     #[builder(default)]
@@ -194,14 +194,14 @@ pub struct AccessTokenRequest {
     /// for access token requests.
     /// Instead, it is usually encoded as a claim in the access token itself.
     ///
-    /// Defined in [section 3.1.1 of RFC 8392](https://www.rfc-editor.org/rfc/rfc8392.html#section-3.1.1)
-    /// and [Figure 16 of `draft-ietf-ace-oauth-authz`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#figure-16).
+    /// Defined in [section 3.1.1 of RFC 8392](https://www.rfc-editor.org/rfc/rfc8392#section-3.1.1)
+    /// and [Table 6 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#table-6).
     #[builder(default)]
     pub issuer: Option<String>,
 }
 
 /// The type of the token issued as described in section 7.1 of
-/// [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-7.1).
+/// [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-7.1).
 ///
 /// Token types are used in the [`AccessTokenResponse`].
 ///
@@ -221,7 +221,7 @@ pub struct AccessTokenRequest {
 /// # Ok::<(), AccessTokenResponseBuilderError>(())
 /// ```
 /// It's also possible to use your own value for a custom token type, as defined in
-/// [section 8.7 of `draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-8.7):
+/// [section 8.7 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-8.7):
 /// ```
 /// # use dcaf::{AccessTokenResponse, GrantType, TokenType};
 /// # use dcaf::endpoints::token_req::AccessTokenResponseBuilderError;
@@ -239,28 +239,27 @@ pub enum TokenType {
     Bearer,
 
     /// Proof-of-possession token type, as specified in
-    /// [`draft-ietf-ace-oauth-params-16`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-params-16.html).
+    /// [RFC 9201](https://www.rfc-editor.org/rfc/rfc9201).
     ProofOfPossession,
 
     /// An unspecified token type along with its representation in CBOR.
     ///
-    /// See [section 8.7 of `draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-8.7)
+    /// See [section 8.7 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-8.7)
     /// for details.
     Other(i32),
 }
 
-/// Profiles for ACE-OAuth as specified in [section 5.8.4.3 of `draft-ietf-ace-oauth-authz`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8.4.3).
+/// Profiles for ACE-OAuth as specified in [section 5.8.4.3 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.8.4.3).
 ///
 /// ACE-OAuth profiles are used in the [`AccessTokenResponse`] if the client previously sent
 /// an [`AccessTokenRequest`] with the `ace_profile` field set.
 ///
-/// There are (to my awareness) at the moment two profiles for ACE-OAuth:
-/// - The DTLS profile, specified in [`draft-ietf-ace-dtls-authorize`](https://www.ietf.org/archive/id/draft-ietf-ace-dtls-authorize-18.html).
-/// - The OSCORE profile, defined in [`draft-ietf-ace-oscore-profile`](https://www.ietf.org/archive/id/draft-ietf-ace-oscore-profile-19.html).
-///   - Note that this is an expired Internet-Draft which does not have a specified CBOR
-///     representation yet. Hence, this is not offered as an option in this enum.
-///     If you wish to use it anyway, you need to specify a user-defined CBOR integer for it
-///     using the [`Other`](AceProfile::Other) variant.
+/// There are at the moment two profiles for ACE-OAuth which are not drafts:
+/// - The DTLS profile, specified in [RFC 9202](https://www.rfc-editor.org/rfc/rfc9202).
+/// - The OSCORE profile, defined in [RFC 9203](https://www.rfc-editor.org/rfc/rfc9203).
+///
+/// If you wish to use a different profile, you need to specify a user-defined CBOR integer for it
+/// using the [`Other`](AceProfile::Other) variant.
 ///
 /// # Example
 /// For example, if you wish to indicate in your response that the DTLS profile is used:
@@ -276,7 +275,7 @@ pub enum TokenType {
 /// # Ok::<(), AccessTokenResponseBuilderError>(())
 /// ```
 /// It's also possible to use your own value for a custom profile, as defined in
-/// [section 8.8 of `draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-8.8):
+/// [section 8.8 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-8.8):
 /// ```
 /// # use dcaf::{AccessTokenResponse, AceProfile};
 /// # use dcaf::endpoints::token_req::AccessTokenResponseBuilderError;
@@ -291,7 +290,7 @@ pub enum TokenType {
 #[non_exhaustive]
 pub enum AceProfile {
     /// Profile for ACE-OAuth using Datagram Transport Layer Security, specified in
-    /// [`draft-ietf-ace-dtls-authorize`](https://www.ietf.org/archive/id/draft-ietf-ace-dtls-authorize-18.html).
+    /// [RFC 9202](https://www.rfc-editor.org/rfc/rfc9202).
     CoapDtls,
 
     // The below is commented out because no CBOR value has been specified yet for this profile.
@@ -300,19 +299,19 @@ pub enum AceProfile {
     // CoapOscore,
     /// An unspecified ACE-OAuth profile along with its representation in CBOR.
     ///
-    /// See [section 8.8 of `draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-8.8)
+    /// See [section 8.8 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-8.8)
     /// for details.
     Other(i32),
 }
 
 /// Response to an [`AccessTokenRequest`] containing the Access Token among additional information,
-/// as defined in [section 5.8.2 of `draft-ietf-ace-oauth-authz`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8.2).
+/// as defined in [section 5.8.2 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.8.2).
 ///
 /// Use the [`AccessTokenResponseBuilder`] (which you can access using the
 /// [`AccessTokenResponse::builder()`] method) to create an instance of this struct.
 ///
 /// # Example
-/// Figure 9 of [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#figure-9)
+/// Figure 7 of [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#figure-7)
 /// gives us an example of an access token response, given in CBOR diagnostic notation[^cbor]:
 /// ```text
 /// {
@@ -384,15 +383,15 @@ pub struct AccessTokenResponse {
     pub expires_in: Option<u32>,
 
     /// The scope of the access token as described by
-    /// section 3.3 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-3.3).
+    /// section 3.3 of [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-3.3).
     ///
     /// See the documentation of [`Scope`] for details.
     #[builder(default)]
     pub scope: Option<Scope>,
 
     /// The type of the token issued as described in [section 7.1 of
-    /// RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-7.1) and [section 5.8.4.2
-    /// of `draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#figure-5.8.4.2).
+    /// RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-7.1) and [section 5.8.4.2
+    /// of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.8.4.2).
     ///
     /// See the documentation of [`TokenType`] for details.
     #[builder(default)]
@@ -400,7 +399,7 @@ pub struct AccessTokenResponse {
 
     /// The refresh token, which can be used to obtain new access tokens using the same
     /// authorization grant as described in [section 6 of
-    /// RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-6).
+    /// RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-6).
     #[builder(default)]
     pub refresh_token: Option<ByteString>,
 
@@ -427,15 +426,15 @@ pub struct AccessTokenResponse {
     /// for access token responses.
     /// It is instead usually encoded as a claim in the access token itself.
     ///
-    /// Defined in [section 3.1.6 of RFC 8392](https://www.rfc-editor.org/rfc/rfc8392.html#section-3.1.6)
-    /// and [Figure 16 of `draft-ietf-ace-oauth-authz`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#figure-16).
+    /// Defined in [section 3.1.6 of RFC 8392](https://www.rfc-editor.org/rfc/rfc8392#section-3.1.6)
+    /// and [table 6 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#table-6).
     #[builder(default)]
     pub issued_at: Option<coset::cwt::Timestamp>,
 }
 
 /// Error code specifying what went wrong for a token request, as specified in
-/// [section 5.2 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-5.2) and
-/// [section 5.8.3 of `draft-ietf-ace-oauth-authz`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8.3).
+/// [section 5.2 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-5.2) and
+/// [section 5.8.3 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.8.3).
 ///
 /// An error code is used in the [`ErrorResponse`].
 ///
@@ -450,7 +449,7 @@ pub struct AccessTokenResponse {
 /// # Ok::<(), ErrorResponseBuilderError>(())
 /// ```
 /// It's also possible to use your own value for a custom error code, as defined in
-/// [section 8.4 of `draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-8.4):
+/// [section 8.4 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-8.4):
 /// ```
 /// # use dcaf::{ErrorResponse, AceProfile, ErrorCode};
 /// # use dcaf::endpoints::token_req::ErrorResponseBuilderError;
@@ -494,20 +493,20 @@ pub enum ErrorCode {
 
     /// An unspecified error code along with its representation in CBOR.
     ///
-    /// See [section 8.4 of `draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-8.4)
+    /// See [section 8.4 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-8.4)
     /// for details.
     Other(i32),
 }
 
 /// Details about an error which occurred for an access token request.
 ///
-/// For more information, see [section 5.8.3 of `draft-ietf-ace-oauth-authz`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8.3).
+/// For more information, see [section 5.8.3 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.8.3).
 ///
 /// Use the [`ErrorResponseBuilder`] (which you can access using the
 /// [`ErrorResponse::builder()`] method) to create an instance of this struct.
 ///
 /// # Example
-/// For example, let us use the example from [section 5.2 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-5.2):
+/// For example, let us use the example from [section 5.2 of RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-5.2):
 /// ```text
 /// {
 ///       "error":"invalid_request"

--- a/src/endpoints/token_req/mod.rs
+++ b/src/endpoints/token_req/mod.rs
@@ -16,13 +16,10 @@
 //! and [`ErrorResponse`]. Look at their documentation for usage examples.
 //! Other members are mainly used as part of the aforementioned structures.
 
-use alloc::string::String;
-
 use coset::AsCborValue;
 
 use crate::common::cbor_values::{ByteString, ProofOfPossessionKey};
 use crate::Scope;
-use coset::AsCborValue;
 
 #[cfg(not(feature = "std"))]
 use {alloc::boxed::Box, alloc::string::String, alloc::vec::Vec};
@@ -633,9 +630,6 @@ mod conversion {
     use crate::constants::cbor_abbreviations::{
         ace_profile, error, grant_types, introspection, token, token_types,
     };
-    use ciborium::value::Value;
-    use coset::cwt::Timestamp;
-    use erased_serde::Serialize as ErasedSerialize;
 
     #[cfg(not(feature = "std"))]
     use {alloc::borrow::ToOwned, alloc::string::ToString};

--- a/src/endpoints/token_req/mod.rs
+++ b/src/endpoints/token_req/mod.rs
@@ -16,6 +16,10 @@
 //! and [`ErrorResponse`]. Look at their documentation for usage examples.
 //! Other members are mainly used as part of the aforementioned structures.
 
+use alloc::string::String;
+
+use coset::AsCborValue;
+
 use crate::common::cbor_values::{ByteString, ProofOfPossessionKey};
 use crate::Scope;
 use coset::AsCborValue;
@@ -293,10 +297,10 @@ pub enum AceProfile {
     /// [RFC 9202](https://www.rfc-editor.org/rfc/rfc9202).
     CoapDtls,
 
-    // The below is commented out because no CBOR value has been specified yet for this profile.
-    // /// Profile for ACE-OAuth using OSCORE, specified in
-    // /// [`draft-ietf-ace-oscore-profile`](https://www.ietf.org/archive/id/draft-ietf-ace-oscore-profile-19.html).
-    // CoapOscore,
+    /// Profile for ACE-OAuth using OSCORE, specified in
+    /// [RFC 9203](https://www.rfc-editor.org/rfc/rfc9203).
+    CoapOscore,
+
     /// An unspecified ACE-OAuth profile along with its representation in CBOR.
     ///
     /// See [section 8.8 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-8.8)
@@ -618,6 +622,10 @@ mod builder {
 }
 
 mod conversion {
+    use ciborium::value::Value;
+    use coset::cwt::Timestamp;
+    use erased_serde::Serialize as ErasedSerialize;
+
     use crate::common::cbor_map::{
         cbor_map_vec, decode_int_map, decode_number, decode_scope, ToCborMap,
     };
@@ -632,7 +640,7 @@ mod conversion {
     #[cfg(not(feature = "std"))]
     use {alloc::borrow::ToOwned, alloc::string::ToString};
 
-    use crate::endpoints::token_req::AceProfile::CoapDtls;
+    use crate::endpoints::token_req::AceProfile::{CoapDtls, CoapOscore};
     use crate::error::TryFromCborMapError;
 
     use super::*;
@@ -685,6 +693,7 @@ mod conversion {
         fn from(value: i32) -> Self {
             match value {
                 ace_profile::COAP_DTLS => CoapDtls,
+                ace_profile::COAP_OSCORE => CoapOscore,
                 x => AceProfile::Other(x),
             }
         }
@@ -694,6 +703,7 @@ mod conversion {
         fn from(profile: AceProfile) -> Self {
             match profile {
                 CoapDtls => ace_profile::COAP_DTLS,
+                CoapOscore => ace_profile::COAP_OSCORE,
                 AceProfile::Other(x) => x,
             }
         }

--- a/src/endpoints/token_req/tests.rs
+++ b/src/endpoints/token_req/tests.rs
@@ -15,19 +15,17 @@ use {alloc::string::ToString, alloc::vec};
 use coset::cwt::Timestamp;
 use coset::iana::Algorithm;
 use coset::{
-    CborSerializable, CoseEncrypt0, CoseEncrypt0Builder, CoseKeyBuilder, HeaderBuilder, iana,
+    iana, CborSerializable, CoseEncrypt0, CoseEncrypt0Builder, CoseKeyBuilder, HeaderBuilder,
     ProtectedHeader,
 };
-use coset::cwt::Timestamp;
-use coset::iana::Algorithm;
-use enumflags2::{BitFlags, make_bitflags};
+use enumflags2::{make_bitflags, BitFlags};
 
-use crate::{AifEncodedScope, BinaryEncodedScope};
 use crate::common::scope::{
     AifEncodedScopeElement, AifRestMethod, LibdcafEncodedScope, TextEncodedScope,
 };
 use crate::common::test_helper::expect_ser_de;
 use crate::endpoints::token_req::AceProfile::{CoapDtls, CoapOscore};
+use crate::{AifEncodedScope, BinaryEncodedScope};
 
 use super::*;
 
@@ -55,7 +53,8 @@ mod request {
             .client_id("myclient")
             .audience("tempSensor4711")
             .scope(
-                BinaryEncodedScope::try_from(vec![0xDC, 0xAF].as_slice()).map_err(|x| x.to_string())?,
+                BinaryEncodedScope::try_from(vec![0xDC, 0xAF].as_slice())
+                    .map_err(|x| x.to_string())?,
             )
             .build()
             .map_err(|x| x.to_string())?;
@@ -79,7 +78,9 @@ mod request {
                 ),
                 AifEncodedScopeElement::new(
                     "dynamic".to_string(),
-                    AifRestMethod::DynamicGet | AifRestMethod::DynamicPost | AifRestMethod::DynamicPut,
+                    AifRestMethod::DynamicGet
+                        | AifRestMethod::DynamicPost
+                        | AifRestMethod::DynamicPut,
                 ),
                 AifEncodedScopeElement::new("unrestricted".to_string(), BitFlags::all()),
                 AifEncodedScopeElement::new("useless".to_string(), BitFlags::empty()),
@@ -123,8 +124,8 @@ mod request {
                 0xbb, 0xfc, 0x11, 0x7e,
             ],
         )
-            .key_id(vec![0x11])
-            .build();
+        .key_id(vec![0x11])
+        .build();
         let request = AccessTokenRequestBuilder::default()
             .client_id("myclient")
             .req_cnf(key)
@@ -206,7 +207,8 @@ mod request {
             .redirect_uri("coaps://server.example.com")
             .grant_type(GrantType::ClientCredentials)
             .scope(
-                BinaryEncodedScope::try_from(vec![0xDC, 0xAF].as_slice()).map_err(|x| x.to_string())?,
+                BinaryEncodedScope::try_from(vec![0xDC, 0xAF].as_slice())
+                    .map_err(|x| x.to_string())?,
             )
             .ace_profile()
             .client_nonce(vec![0, 1, 2, 3, 4])
@@ -214,8 +216,6 @@ mod request {
             .map_err(|x| x.to_string())?;
         expect_ser_de(request, None, "A60942DCAF1818686D79636C69656E74181B781A636F6170733A2F2F7365727665722E6578616D706C652E636F6D1821021826F61827450001020304")
     }
-
-
 }
 
 mod response {
@@ -233,7 +233,9 @@ mod response {
                 ),
                 AifEncodedScopeElement::new(
                     "dynamic".to_string(),
-                    AifRestMethod::DynamicGet | AifRestMethod::DynamicPost | AifRestMethod::DynamicPut,
+                    AifRestMethod::DynamicGet
+                        | AifRestMethod::DynamicPost
+                        | AifRestMethod::DynamicPut,
                 ),
                 AifEncodedScopeElement::new("unrestricted".to_string(), BitFlags::all()),
                 AifEncodedScopeElement::new("useless".to_string(), BitFlags::empty()),
@@ -273,11 +275,11 @@ mod response {
     #[test]
     fn test_access_token_response() -> Result<(), String> {
         let key = CoseKeyBuilder::new_symmetric_key(vec![
-            0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c, 0x14, 0x91, 0xbe, 0x3a, 0x76, 0xdc, 0xea, 0x6c, 0x42,
-            0x71, 0x08,
+            0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c, 0x14, 0x91, 0xbe, 0x3a, 0x76, 0xdc, 0xea, 0x6c,
+            0x42, 0x71, 0x08,
         ])
-            .key_id(vec![0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c])
-            .build();
+        .key_id(vec![0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c])
+        .build();
         // We need to specify this here because otherwise it'd be typed as an i32.
         let expires_in: u32 = 3600;
         let response = AccessTokenResponseBuilder::default()
@@ -293,11 +295,11 @@ mod response {
     #[test]
     fn test_access_token_response_oscore() -> Result<(), String> {
         let key = CoseKeyBuilder::new_symmetric_key(vec![
-            0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c, 0x14, 0x91, 0xbe, 0x3a, 0x76, 0xdc, 0xea, 0x6c, 0x42,
-            0x71, 0x08,
+            0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c, 0x14, 0x91, 0xbe, 0x3a, 0x76, 0xdc, 0xea, 0x6c,
+            0x42, 0x71, 0x08,
         ])
-            .key_id(vec![0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c])
-            .build();
+        .key_id(vec![0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c])
+        .build();
         // We need to specify this here because otherwise it'd be typed as an i32.
         let expires_in: u32 = 3600;
         let response = AccessTokenResponseBuilder::default()
@@ -336,4 +338,3 @@ mod error {
         expect_ser_de(error, None, "A3181E1901A2181F7824492063616E27742068656C7020796F752C2049276D206A757374206120746561706F742E18207468747470733A2F2F687474702E6361742F343138")
     }
 }
-

--- a/src/endpoints/token_req/tests.rs
+++ b/src/endpoints/token_req/tests.rs
@@ -29,274 +29,290 @@ use crate::{AifEncodedScope, BinaryEncodedScope};
 
 use super::*;
 
-/// Example data taken from draft-ietf-ace-oauth-authz-46, Figure 5.
-#[test]
-fn test_access_token_request_symmetric() -> Result<(), String> {
-    let request = AccessTokenRequestBuilder::default()
-        .client_id("myclient")
-        .audience("tempSensor4711")
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(
-        request,
-        None,
-        "A2056E74656D7053656E736F72343731311818686D79636C69656E74",
-    )
-}
 
-#[test]
-fn test_access_token_request_binary() -> Result<(), String> {
-    let request = AccessTokenRequestBuilder::default()
-        .client_id("myclient")
-        .audience("tempSensor4711")
-        .scope(
-            BinaryEncodedScope::try_from(vec![0xDC, 0xAF].as_slice()).map_err(|x| x.to_string())?,
+mod request {
+    use super::*;
+
+    /// Example data taken from draft-ietf-ace-oauth-authz-46, Figure 5.
+    #[test]
+    fn test_access_token_request_symmetric() -> Result<(), String> {
+        let request = AccessTokenRequestBuilder::default()
+            .client_id("myclient")
+            .audience("tempSensor4711")
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(
+            request,
+            None,
+            "A2056E74656D7053656E736F72343731311818686D79636C69656E74",
         )
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(
-        request,
-        None,
-        "A3056E74656D7053656E736F72343731310942DCAF1818686D79636C69656E74",
-    )
-}
-
-#[test]
-fn test_access_token_request_aif() -> Result<(), String> {
-    let request = AccessTokenRequest::builder()
-        .client_id("testclient")
-        .audience("coaps://localhost")
-        .scope(AifEncodedScope::new(vec![
-            AifEncodedScopeElement::new("restricted".to_string(), AifRestMethod::Get),
-            AifEncodedScopeElement::new(
-                "extended".to_string(),
-                AifRestMethod::Get | AifRestMethod::Post | AifRestMethod::Put,
-            ),
-            AifEncodedScopeElement::new(
-                "dynamic".to_string(),
-                AifRestMethod::DynamicGet | AifRestMethod::DynamicPost | AifRestMethod::DynamicPut,
-            ),
-            AifEncodedScopeElement::new("unrestricted".to_string(), BitFlags::all()),
-            AifEncodedScopeElement::new("useless".to_string(), BitFlags::empty()),
-        ]))
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(request,
-                  None,
-                  "A30571636F6170733A2F2F6C6F63616C686F73740985826A72657374726963746564018268657874656E64656407826764796E616D69631B0000000700000000826C756E726573747269637465641B0000007F0000007F82677573656C6573730018186A74657374636C69656E74")
-}
-
-#[test]
-fn test_access_token_response_aif() -> Result<(), String> {
-    let request = AccessTokenResponse::builder()
-        .access_token(vec![0xDC, 0xAF])
-        .scope(AifEncodedScope::new(vec![
-            AifEncodedScopeElement::new("restricted".to_string(), AifRestMethod::Get),
-            AifEncodedScopeElement::new(
-                "extended".to_string(),
-                AifRestMethod::Get | AifRestMethod::Post | AifRestMethod::Put,
-            ),
-            AifEncodedScopeElement::new(
-                "dynamic".to_string(),
-                AifRestMethod::DynamicGet | AifRestMethod::DynamicPost | AifRestMethod::DynamicPut,
-            ),
-            AifEncodedScopeElement::new("unrestricted".to_string(), BitFlags::all()),
-            AifEncodedScopeElement::new("useless".to_string(), BitFlags::empty()),
-        ]))
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(request,
-                  None,
-                  "A20142DCAF0985826A72657374726963746564018268657874656E64656407826764796E616D69631B0000000700000000826C756E726573747269637465641B0000007F0000007F82677573656C65737300")
-}
-
-#[test]
-fn test_access_token_request_libdcaf() -> Result<(), String> {
-    let request = AccessTokenRequest::builder()
-        .audience("coaps://localhost")
-        .scope(LibdcafEncodedScope::new(
-            "restricted",
-            make_bitflags!(AifRestMethod::{Get}),
-        ))
-        .issuer("coaps://127.0.0.1:7744/authorize")
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(request,
-                  None,
-                  "A3017820636F6170733A2F2F3132372E302E302E313A373734342F617574686F72697A650571636F6170733A2F2F6C6F63616C686F737409826A7265737472696374656401")
-}
-
-#[test]
-fn test_access_token_response_whole_libdcaf() -> Result<(), String> {
-    let response = AccessTokenResponse::builder()
-        .access_token(vec![0xDC, 0xAF])
-        .scope(LibdcafEncodedScope::new(
-            "restricted",
-            make_bitflags!(AifRestMethod::{Get}),
-        ))
-        .issued_at(Timestamp::WholeSeconds(10))
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(response, None, "A30142DCAF060A09826A7265737472696374656401")
-}
-
-#[test]
-fn test_access_token_response_fraction_libdcaf() -> Result<(), String> {
-    let response = AccessTokenResponse::builder()
-        .access_token(vec![0xDC, 0xAF])
-        .scope(LibdcafEncodedScope::new("empty", BitFlags::empty()))
-        .issued_at(Timestamp::FractionalSeconds(1.5))
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(response, None, "A30142DCAF06F93E00098265656D70747900")
-}
-
-/// Example data taken from draft-ietf-ace-oauth-authz-46, Figure 6.
-#[test]
-fn test_access_token_request_asymmetric() -> Result<(), String> {
-    let key = CoseKeyBuilder::new_ec2_pub_key(
-        iana::EllipticCurve::P_256,
-        vec![
-            0xba, 0xc5, 0xb1, 0x1c, 0xad, 0x8f, 0x99, 0xf9, 0xc7, 0x2b, 0x05, 0xcf, 0x4b, 0x9e,
-            0x26, 0xd2, 0x44, 0xdc, 0x18, 0x9f, 0x74, 0x52, 0x28, 0x25, 0x5a, 0x21, 0x9a, 0x86,
-            0xd6, 0xa0, 0x9e, 0xff,
-        ],
-        vec![
-            0x20, 0x13, 0x8b, 0xf8, 0x2d, 0xc1, 0xb6, 0xd5, 0x62, 0xbe, 0x0f, 0xa5, 0x4a, 0xb7,
-            0x80, 0x4a, 0x3a, 0x64, 0xb6, 0xd7, 0x2c, 0xcf, 0xed, 0x6b, 0x6f, 0xb6, 0xed, 0x28,
-            0xbb, 0xfc, 0x11, 0x7e,
-        ],
-    )
-    .key_id(vec![0x11])
-    .build();
-    let request = AccessTokenRequestBuilder::default()
-        .client_id("myclient")
-        .req_cnf(key)
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(request, None, "A204A101A501020241112001215820BAC5B11CAD8F99F9C72B05CF4B9E26D244DC189F745228255A219A86D6A09EFF22582020138BF82DC1B6D562BE0FA54AB7804A3A64B6D72CCFED6B6FB6ED28BBFC117E1818686D79636C69656E74")
-}
-
-/// Example data taken from draft-ietf-ace-oauth-authz-46, Figure 7.
-#[test]
-fn test_access_token_request_reference() -> Result<(), String> {
-    let request = AccessTokenRequestBuilder::default()
-        .client_id("myclient")
-        .audience("valve424")
-        .scope(TextEncodedScope::try_from("read").map_err(|x| x.to_string())?)
-        .req_cnf(vec![0xea, 0x48, 0x34, 0x75, 0x72, 0x4c, 0xd7, 0x75])
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(
-        request,
-        None,
-        "A404A10348EA483475724CD775056876616C76653432340964726561641818686D79636C69656E74",
-    )
-}
-
-#[test]
-fn test_access_token_request_encrypted() -> Result<(), String> {
-    // Extract relevant part for comparison (i.e. no protected headers' original data,
-    // which can change after serialization)
-    fn transform_header(mut request: AccessTokenRequest) -> AccessTokenRequest {
-        let enc: CoseEncrypt0 = request
-            .req_cnf
-            .expect("No req_cnf present")
-            .try_into()
-            .expect("Key is not encrypted");
-        request.req_cnf = Some(ProofOfPossessionKey::EncryptedCoseKey(CoseEncrypt0 {
-            protected: ProtectedHeader {
-                original_data: None,
-                ..enc.protected
-            },
-            ..enc
-        }));
-        request
     }
 
-    let unprotected_header = HeaderBuilder::new()
-        .iv(vec![
-            0x63, 0x68, 0x98, 0x99, 0x4F, 0xF0, 0xEC, 0x7B, 0xFC, 0xF6, 0xD3, 0xF9, 0x5B,
-        ])
-        .build();
-    let protected_header = HeaderBuilder::new()
-        .algorithm(Algorithm::AES_CCM_16_64_128)
-        .build();
-    let encrypted = CoseEncrypt0Builder::new()
-        .protected(protected_header)
-        .unprotected(unprotected_header)
-        .ciphertext(vec![
-            0x05, 0x73, 0x31, 0x8A, 0x35, 0x73, 0xEB, 0x98, 0x3E, 0x55, 0xA7, 0xC2, 0xF0, 0x6C,
-            0xAD, 0xD0, 0x79, 0x6C, 0x9E, 0x58, 0x4F, 0x1D, 0x0E, 0x3E, 0xA8, 0xC5, 0xB0, 0x52,
-            0x59, 0x2A, 0x8B, 0x26, 0x94, 0xBE, 0x96, 0x54, 0xF0, 0x43, 0x1F, 0x38, 0xD5, 0xBB,
-            0xC8, 0x04, 0x9F, 0xA7, 0xF1, 0x3F,
-        ])
-        .build();
-    assert_eq!(hex::encode_upper(encrypted.clone().to_vec().map_err(|x| x.to_string())?),
-               "8343A1010AA1054D636898994FF0EC7BFCF6D3F95B58300573318A3573EB983E55A7C2F06CADD0796C9E584F1D0E3EA8C5B052592A8B2694BE9654F0431F38D5BBC8049FA7F13F");
-    let request = AccessTokenRequestBuilder::default()
-        .client_id("myclient")
-        .req_cnf(encrypted)
-        .build()
-        .map_err(|x| x.to_string())?;
-
-    expect_ser_de(request, Some(transform_header), "A204A1028343A1010AA1054D636898994FF0EC7BFCF6D3F95B58300573318A3573EB983E55A7C2F06CADD0796C9E584F1D0E3EA8C5B052592A8B2694BE9654F0431F38D5BBC8049FA7F13F1818686D79636C69656E74")
-}
-
-#[test]
-fn test_access_token_request_other_fields() -> Result<(), String> {
-    let request = AccessTokenRequestBuilder::default()
-        .client_id("myclient")
-        .redirect_uri("coaps://server.example.com")
-        .grant_type(GrantType::ClientCredentials)
-        .scope(
-            BinaryEncodedScope::try_from(vec![0xDC, 0xAF].as_slice()).map_err(|x| x.to_string())?,
+    #[test]
+    fn test_access_token_request_binary() -> Result<(), String> {
+        let request = AccessTokenRequestBuilder::default()
+            .client_id("myclient")
+            .audience("tempSensor4711")
+            .scope(
+                BinaryEncodedScope::try_from(vec![0xDC, 0xAF].as_slice()).map_err(|x| x.to_string())?,
+            )
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(
+            request,
+            None,
+            "A3056E74656D7053656E736F72343731310942DCAF1818686D79636C69656E74",
         )
-        .ace_profile()
-        .client_nonce(vec![0, 1, 2, 3, 4])
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(request, None, "A60942DCAF1818686D79636C69656E74181B781A636F6170733A2F2F7365727665722E6578616D706C652E636F6D1821021826F61827450001020304")
+    }
+
+    #[test]
+    fn test_access_token_request_aif() -> Result<(), String> {
+        let request = AccessTokenRequest::builder()
+            .client_id("testclient")
+            .audience("coaps://localhost")
+            .scope(AifEncodedScope::new(vec![
+                AifEncodedScopeElement::new("restricted".to_string(), AifRestMethod::Get),
+                AifEncodedScopeElement::new(
+                    "extended".to_string(),
+                    AifRestMethod::Get | AifRestMethod::Post | AifRestMethod::Put,
+                ),
+                AifEncodedScopeElement::new(
+                    "dynamic".to_string(),
+                    AifRestMethod::DynamicGet | AifRestMethod::DynamicPost | AifRestMethod::DynamicPut,
+                ),
+                AifEncodedScopeElement::new("unrestricted".to_string(), BitFlags::all()),
+                AifEncodedScopeElement::new("useless".to_string(), BitFlags::empty()),
+            ]))
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(request,
+                      None,
+                      "A30571636F6170733A2F2F6C6F63616C686F73740985826A72657374726963746564018268657874656E64656407826764796E616D69631B0000000700000000826C756E726573747269637465641B0000007F0000007F82677573656C6573730018186A74657374636C69656E74")
+    }
+
+    #[test]
+    fn test_access_token_request_libdcaf() -> Result<(), String> {
+        let request = AccessTokenRequest::builder()
+            .audience("coaps://localhost")
+            .scope(LibdcafEncodedScope::new(
+                "restricted",
+                make_bitflags!(AifRestMethod::{Get}),
+            ))
+            .issuer("coaps://127.0.0.1:7744/authorize")
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(request,
+                      None,
+                      "A3017820636F6170733A2F2F3132372E302E302E313A373734342F617574686F72697A650571636F6170733A2F2F6C6F63616C686F737409826A7265737472696374656401")
+    }
+
+    /// Example data taken from draft-ietf-ace-oauth-authz-46, Figure 6.
+    #[test]
+    fn test_access_token_request_asymmetric() -> Result<(), String> {
+        let key = CoseKeyBuilder::new_ec2_pub_key(
+            iana::EllipticCurve::P_256,
+            vec![
+                0xba, 0xc5, 0xb1, 0x1c, 0xad, 0x8f, 0x99, 0xf9, 0xc7, 0x2b, 0x05, 0xcf, 0x4b, 0x9e,
+                0x26, 0xd2, 0x44, 0xdc, 0x18, 0x9f, 0x74, 0x52, 0x28, 0x25, 0x5a, 0x21, 0x9a, 0x86,
+                0xd6, 0xa0, 0x9e, 0xff,
+            ],
+            vec![
+                0x20, 0x13, 0x8b, 0xf8, 0x2d, 0xc1, 0xb6, 0xd5, 0x62, 0xbe, 0x0f, 0xa5, 0x4a, 0xb7,
+                0x80, 0x4a, 0x3a, 0x64, 0xb6, 0xd7, 0x2c, 0xcf, 0xed, 0x6b, 0x6f, 0xb6, 0xed, 0x28,
+                0xbb, 0xfc, 0x11, 0x7e,
+            ],
+        )
+            .key_id(vec![0x11])
+            .build();
+        let request = AccessTokenRequestBuilder::default()
+            .client_id("myclient")
+            .req_cnf(key)
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(request, None, "A204A101A501020241112001215820BAC5B11CAD8F99F9C72B05CF4B9E26D244DC189F745228255A219A86D6A09EFF22582020138BF82DC1B6D562BE0FA54AB7804A3A64B6D72CCFED6B6FB6ED28BBFC117E1818686D79636C69656E74")
+    }
+
+    /// Example data taken from draft-ietf-ace-oauth-authz-46, Figure 7.
+    #[test]
+    fn test_access_token_request_reference() -> Result<(), String> {
+        let request = AccessTokenRequestBuilder::default()
+            .client_id("myclient")
+            .audience("valve424")
+            .scope(TextEncodedScope::try_from("read").map_err(|x| x.to_string())?)
+            .req_cnf(vec![0xea, 0x48, 0x34, 0x75, 0x72, 0x4c, 0xd7, 0x75])
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(
+            request,
+            None,
+            "A404A10348EA483475724CD775056876616C76653432340964726561641818686D79636C69656E74",
+        )
+    }
+
+    #[test]
+    fn test_access_token_request_encrypted() -> Result<(), String> {
+        // Extract relevant part for comparison (i.e. no protected headers' original data,
+        // which can change after serialization)
+        fn transform_header(mut request: AccessTokenRequest) -> AccessTokenRequest {
+            let enc: CoseEncrypt0 = request
+                .req_cnf
+                .expect("No req_cnf present")
+                .try_into()
+                .expect("Key is not encrypted");
+            request.req_cnf = Some(ProofOfPossessionKey::EncryptedCoseKey(CoseEncrypt0 {
+                protected: ProtectedHeader {
+                    original_data: None,
+                    ..enc.protected
+                },
+                ..enc
+            }));
+            request
+        }
+
+        let unprotected_header = HeaderBuilder::new()
+            .iv(vec![
+                0x63, 0x68, 0x98, 0x99, 0x4F, 0xF0, 0xEC, 0x7B, 0xFC, 0xF6, 0xD3, 0xF9, 0x5B,
+            ])
+            .build();
+        let protected_header = HeaderBuilder::new()
+            .algorithm(Algorithm::AES_CCM_16_64_128)
+            .build();
+        let encrypted = CoseEncrypt0Builder::new()
+            .protected(protected_header)
+            .unprotected(unprotected_header)
+            .ciphertext(vec![
+                0x05, 0x73, 0x31, 0x8A, 0x35, 0x73, 0xEB, 0x98, 0x3E, 0x55, 0xA7, 0xC2, 0xF0, 0x6C,
+                0xAD, 0xD0, 0x79, 0x6C, 0x9E, 0x58, 0x4F, 0x1D, 0x0E, 0x3E, 0xA8, 0xC5, 0xB0, 0x52,
+                0x59, 0x2A, 0x8B, 0x26, 0x94, 0xBE, 0x96, 0x54, 0xF0, 0x43, 0x1F, 0x38, 0xD5, 0xBB,
+                0xC8, 0x04, 0x9F, 0xA7, 0xF1, 0x3F,
+            ])
+            .build();
+        assert_eq!(hex::encode_upper(encrypted.clone().to_vec().map_err(|x| x.to_string())?),
+                   "8343A1010AA1054D636898994FF0EC7BFCF6D3F95B58300573318A3573EB983E55A7C2F06CADD0796C9E584F1D0E3EA8C5B052592A8B2694BE9654F0431F38D5BBC8049FA7F13F");
+        let request = AccessTokenRequestBuilder::default()
+            .client_id("myclient")
+            .req_cnf(encrypted)
+            .build()
+            .map_err(|x| x.to_string())?;
+
+        expect_ser_de(request, Some(transform_header), "A204A1028343A1010AA1054D636898994FF0EC7BFCF6D3F95B58300573318A3573EB983E55A7C2F06CADD0796C9E584F1D0E3EA8C5B052592A8B2694BE9654F0431F38D5BBC8049FA7F13F1818686D79636C69656E74")
+    }
+
+    #[test]
+    fn test_access_token_request_other_fields() -> Result<(), String> {
+        let request = AccessTokenRequestBuilder::default()
+            .client_id("myclient")
+            .redirect_uri("coaps://server.example.com")
+            .grant_type(GrantType::ClientCredentials)
+            .scope(
+                BinaryEncodedScope::try_from(vec![0xDC, 0xAF].as_slice()).map_err(|x| x.to_string())?,
+            )
+            .ace_profile()
+            .client_nonce(vec![0, 1, 2, 3, 4])
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(request, None, "A60942DCAF1818686D79636C69656E74181B781A636F6170733A2F2F7365727665722E6578616D706C652E636F6D1821021826F61827450001020304")
+    }
+
+
 }
 
-#[test]
-fn test_access_token_response() -> Result<(), String> {
-    let key = CoseKeyBuilder::new_symmetric_key(vec![
-        0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c, 0x14, 0x91, 0xbe, 0x3a, 0x76, 0xdc, 0xea, 0x6c, 0x42,
-        0x71, 0x08,
-    ])
-    .key_id(vec![0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c])
-    .build();
-    // We need to specify this here because otherwise it'd be typed as an i32.
-    let expires_in: u32 = 3600;
-    let response = AccessTokenResponseBuilder::default()
-        .access_token(hex::decode("4a5015df686428").map_err(|x| x.to_string())?)
-        .ace_profile(CoapDtls)
-        .expires_in(expires_in)
-        .cnf(key)
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(response, None, "A401474A5015DF68642802190E1008A101A301040246849B5786457C2051849B5786457C1491BE3A76DCEA6C427108182601")
+mod response {
+    use super::*;
+
+    #[test]
+    fn test_access_token_response_aif() -> Result<(), String> {
+        let request = AccessTokenResponse::builder()
+            .access_token(vec![0xDC, 0xAF])
+            .scope(AifEncodedScope::new(vec![
+                AifEncodedScopeElement::new("restricted".to_string(), AifRestMethod::Get),
+                AifEncodedScopeElement::new(
+                    "extended".to_string(),
+                    AifRestMethod::Get | AifRestMethod::Post | AifRestMethod::Put,
+                ),
+                AifEncodedScopeElement::new(
+                    "dynamic".to_string(),
+                    AifRestMethod::DynamicGet | AifRestMethod::DynamicPost | AifRestMethod::DynamicPut,
+                ),
+                AifEncodedScopeElement::new("unrestricted".to_string(), BitFlags::all()),
+                AifEncodedScopeElement::new("useless".to_string(), BitFlags::empty()),
+            ]))
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(request,
+                      None,
+                      "A20142DCAF0985826A72657374726963746564018268657874656E64656407826764796E616D69631B0000000700000000826C756E726573747269637465641B0000007F0000007F82677573656C65737300")
+    }
+
+    #[test]
+    fn test_access_token_response_whole_libdcaf() -> Result<(), String> {
+        let response = AccessTokenResponse::builder()
+            .access_token(vec![0xDC, 0xAF])
+            .scope(LibdcafEncodedScope::new(
+                "restricted",
+                make_bitflags!(AifRestMethod::{Get}),
+            ))
+            .issued_at(Timestamp::WholeSeconds(10))
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(response, None, "A30142DCAF060A09826A7265737472696374656401")
+    }
+
+    #[test]
+    fn test_access_token_response_fraction_libdcaf() -> Result<(), String> {
+        let response = AccessTokenResponse::builder()
+            .access_token(vec![0xDC, 0xAF])
+            .scope(LibdcafEncodedScope::new("empty", BitFlags::empty()))
+            .issued_at(Timestamp::FractionalSeconds(1.5))
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(response, None, "A30142DCAF06F93E00098265656D70747900")
+    }
+
+    #[test]
+    fn test_access_token_response() -> Result<(), String> {
+        let key = CoseKeyBuilder::new_symmetric_key(vec![
+            0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c, 0x14, 0x91, 0xbe, 0x3a, 0x76, 0xdc, 0xea, 0x6c, 0x42,
+            0x71, 0x08,
+        ])
+            .key_id(vec![0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c])
+            .build();
+        // We need to specify this here because otherwise it'd be typed as an i32.
+        let expires_in: u32 = 3600;
+        let response = AccessTokenResponseBuilder::default()
+            .access_token(hex::decode("4a5015df686428").map_err(|x| x.to_string())?)
+            .ace_profile(CoapDtls)
+            .expires_in(expires_in)
+            .cnf(key)
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(response, None, "A401474A5015DF68642802190E1008A101A301040246849B5786457C2051849B5786457C1491BE3A76DCEA6C427108182601")
+    }
 }
 
-#[test]
-fn test_error_response() -> Result<(), String> {
-    let error = ErrorResponse::builder()
-        .error(ErrorCode::UnauthorizedClient)
-        .description("You are not authorized to receive this token.")
-        .uri("https://http.cat/401")
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(error, None, "A3181E04181F782D596F7520617265206E6F7420617574686F72697A656420746F2072656365697665207468697320746F6B656E2E18207468747470733A2F2F687474702E6361742F343031")
+mod error {
+    use super::*;
+
+    #[test]
+    fn test_error_response() -> Result<(), String> {
+        let error = ErrorResponse::builder()
+            .error(ErrorCode::UnauthorizedClient)
+            .description("You are not authorized to receive this token.")
+            .uri("https://http.cat/401")
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(error, None, "A3181E04181F782D596F7520617265206E6F7420617574686F72697A656420746F2072656365697665207468697320746F6B656E2E18207468747470733A2F2F687474702E6361742F343031")
+    }
+
+    #[test]
+    fn test_error_response_other() -> Result<(), String> {
+        let error = ErrorResponse::builder()
+            .error(ErrorCode::Other(418))
+            .description("I can't help you, I'm just a teapot.")
+            .uri("https://http.cat/418")
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(error, None, "A3181E1901A2181F7824492063616E27742068656C7020796F752C2049276D206A757374206120746561706F742E18207468747470733A2F2F687474702E6361742F343138")
+    }
 }
 
-#[test]
-fn test_error_response_other() -> Result<(), String> {
-    let error = ErrorResponse::builder()
-        .error(ErrorCode::Other(418))
-        .description("I can't help you, I'm just a teapot.")
-        .uri("https://http.cat/418")
-        .build()
-        .map_err(|x| x.to_string())?;
-    expect_ser_de(error, None, "A3181E1901A2181F7824492063616E27742068656C7020796F752C2049276D206A757374206120746561706F742E18207468747470733A2F2F687474702E6361742F343138")
-}

--- a/src/endpoints/token_req/tests.rs
+++ b/src/endpoints/token_req/tests.rs
@@ -15,25 +15,26 @@ use {alloc::string::ToString, alloc::vec};
 use coset::cwt::Timestamp;
 use coset::iana::Algorithm;
 use coset::{
-    iana, CborSerializable, CoseEncrypt0, CoseEncrypt0Builder, CoseKeyBuilder, HeaderBuilder,
+    CborSerializable, CoseEncrypt0, CoseEncrypt0Builder, CoseKeyBuilder, HeaderBuilder, iana,
     ProtectedHeader,
 };
-use enumflags2::{make_bitflags, BitFlags};
+use coset::cwt::Timestamp;
+use coset::iana::Algorithm;
+use enumflags2::{BitFlags, make_bitflags};
 
+use crate::{AifEncodedScope, BinaryEncodedScope};
 use crate::common::scope::{
     AifEncodedScopeElement, AifRestMethod, LibdcafEncodedScope, TextEncodedScope,
 };
 use crate::common::test_helper::expect_ser_de;
 use crate::endpoints::token_req::AceProfile::CoapDtls;
-use crate::{AifEncodedScope, BinaryEncodedScope};
 
 use super::*;
-
 
 mod request {
     use super::*;
 
-    /// Example data taken from draft-ietf-ace-oauth-authz-46, Figure 5.
+    /// Example data taken from RFC 9200, Figure 4.
     #[test]
     fn test_access_token_request_symmetric() -> Result<(), String> {
         let request = AccessTokenRequestBuilder::default()
@@ -106,7 +107,7 @@ mod request {
                       "A3017820636F6170733A2F2F3132372E302E302E313A373734342F617574686F72697A650571636F6170733A2F2F6C6F63616C686F737409826A7265737472696374656401")
     }
 
-    /// Example data taken from draft-ietf-ace-oauth-authz-46, Figure 6.
+    /// Example data taken from RFC 9200, Figure 5.
     #[test]
     fn test_access_token_request_asymmetric() -> Result<(), String> {
         let key = CoseKeyBuilder::new_ec2_pub_key(
@@ -132,7 +133,7 @@ mod request {
         expect_ser_de(request, None, "A204A101A501020241112001215820BAC5B11CAD8F99F9C72B05CF4B9E26D244DC189F745228255A219A86D6A09EFF22582020138BF82DC1B6D562BE0FA54AB7804A3A64B6D72CCFED6B6FB6ED28BBFC117E1818686D79636C69656E74")
     }
 
-    /// Example data taken from draft-ietf-ace-oauth-authz-46, Figure 7.
+    /// Example data taken from RFC 9200, Figure 6.
     #[test]
     fn test_access_token_request_reference() -> Result<(), String> {
         let request = AccessTokenRequestBuilder::default()

--- a/src/endpoints/token_req/tests.rs
+++ b/src/endpoints/token_req/tests.rs
@@ -27,7 +27,7 @@ use crate::common::scope::{
     AifEncodedScopeElement, AifRestMethod, LibdcafEncodedScope, TextEncodedScope,
 };
 use crate::common::test_helper::expect_ser_de;
-use crate::endpoints::token_req::AceProfile::CoapDtls;
+use crate::endpoints::token_req::AceProfile::{CoapDtls, CoapOscore};
 
 use super::*;
 
@@ -288,6 +288,26 @@ mod response {
             .build()
             .map_err(|x| x.to_string())?;
         expect_ser_de(response, None, "A401474A5015DF68642802190E1008A101A301040246849B5786457C2051849B5786457C1491BE3A76DCEA6C427108182601")
+    }
+
+    #[test]
+    fn test_access_token_response_oscore() -> Result<(), String> {
+        let key = CoseKeyBuilder::new_symmetric_key(vec![
+            0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c, 0x14, 0x91, 0xbe, 0x3a, 0x76, 0xdc, 0xea, 0x6c, 0x42,
+            0x71, 0x08,
+        ])
+            .key_id(vec![0x84, 0x9b, 0x57, 0x86, 0x45, 0x7c])
+            .build();
+        // We need to specify this here because otherwise it'd be typed as an i32.
+        let expires_in: u32 = 3600;
+        let response = AccessTokenResponseBuilder::default()
+            .access_token(hex::decode("4a5015df686428").map_err(|x| x.to_string())?)
+            .ace_profile(CoapOscore)
+            .expires_in(expires_in)
+            .cnf(key)
+            .build()
+            .map_err(|x| x.to_string())?;
+        expect_ser_de(response, None, "A401474A5015DF68642802190E1008A101A301040246849B5786457C2051849B5786457C1491BE3A76DCEA6C427108182602")
     }
 }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -178,7 +178,7 @@ impl Display for InvalidTextEncodedScopeError {
 }
 
 /// Error type used when a [`BinaryEncodedScope`](crate::common::scope::BinaryEncodedScope)
-/// does not conform to the specification given in RFC 6749 and `draft-ietf-ace-oauth-authz`.
+/// does not conform to the specification given in RFC 6749 and RFC 9200.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum InvalidBinaryEncodedScopeError {
     /// Scope starts with a separator, which is contained in the field here.
@@ -210,7 +210,7 @@ impl Display for InvalidBinaryEncodedScopeError {
 
 /// Error type used when an [`AifEncodedScope`](crate::common::scope::AifEncodedScope)
 /// does not conform to the specification given in [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) and
-/// [`draft-ietf-ace-aif`](https://datatracker.ietf.org/doc/html/draft-ietf-ace-aif).
+/// [RFC 9237](https://www.rfc-editor.org/rfc/rfc9237).
 ///
 /// This is also used when a [`LibdcafEncodedScope`](crate::common::scope::LibdcafEncodedScope)
 /// does not conform to the format specified in its documentation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,19 +9,19 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
 
-//! An implementation of the [ACE-OAuth framework](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+//! An implementation of the [ACE-OAuth framework (RFC 9200)](https://www.rfc-editor.org/rfc/rfc9200).
 //!
 //! This crate implements the ACE-OAuth
 //! (Authentication and Authorization for Constrained Environments using the OAuth 2.0 Framework)
-//! framework as defined in [`draft-ietf-ace-oauth-authz-46`](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html).
+//! framework as defined in [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200).
 //! Key features include CBOR-(de-)serializable data models such as [`AccessTokenRequest`],
 //! as well as the possibility to create COSE encrypted/signed access tokens
-//! (as described in the draft) along with decryption/verification functions.
+//! (as described in the standard) along with decryption/verification functions.
 //! Implementations of the cryptographic functions must be provided by the user by implementing
 //! [`CoseEncrypt0Cipher`] or [`CoseSign1Cipher`].
 //!
-//! Note that actually transmitting the serialized values (e.g. via CoAP) or providing more complex
-//! features not mentioned in the ACE-OAuth Internet Draft (e.g. a permission management system for
+//! Note that actually transmitting the serialized values (e.g., via CoAP) or providing more complex
+//! features not mentioned in the ACE-OAuth RFC (e.g., a permission management system for
 //! the Authorization Server) is *out of scope* for this crate.
 //! This also applies to cryptographic functions, as mentioned in the previous paragraph.
 //!
@@ -55,8 +55,8 @@
 //! token creation/verification functions. We'll quickly introduce both of these here.
 //!
 //! ## Data models
-//! [For example](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#figure-7),
-//! say you (the client) want to request an access token from an Authorization Server.
+//! [For example](https://www.rfc-editor.org/rfc/rfc9200#figure-6),
+//! let's assume you (the client) want to request an access token from an Authorization Server.
 //! For this, you'd need to create an [`AccessTokenRequest`], which has to include at least a
 //! `client_id`. We'll also specify an audience, a scope (using [`TextEncodedScope`]---note that
 //! [binary-encoded scopes](BinaryEncodedScope) or [AIF-encoded scopes](AifEncodedScope) would also work), as well as a
@@ -133,18 +133,18 @@
 //!
 //! ## Token Endpoint
 //! The most commonly used models will probably be the token endpoint's [`AccessTokenRequest`] and
-//! [`AccessTokenResponse`] described in [section 5.8 of the ACE-OAuth draft](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8).
+//! [`AccessTokenResponse`] described in [section 5.8 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.8).
 //! In case of an error, an [`ErrorResponse`] should be used.
 //!
 //! After an initial Unauthorized Resource Request Message, an [`AuthServerRequestCreationHint`] can
 //! be used to provide additional information to the client, as described in
-//! [section 5.3 of the ACE-OAuth draft](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.3).
+//! [section 5.3 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.3).
 //!
 //! ## Common Data Types
 //! Some types used across multiple scenarios include:
-//! - [`Scope`] (as described in [section 5.8.1 of the ACE-OAuth draft](https://www.ietf.org/archive/id/draft-ietf-ace-oauth-authz-46.html#section-5.8.1)),
+//! - [`Scope`] (as described in [section 5.8.1 of RFC 9200](https://www.rfc-editor.org/rfc/rfc9200#section-5.8.1)),
 //!   either as a [`TextEncodedScope`], a [`BinaryEncodedScope`] or an [`AifEncodedScope`].
-//! - [`ProofOfPossessionKey`] as specified in [section 3.1 of RFC 8747](https://datatracker.ietf.org/doc/html/rfc8747#section-3.1).
+//! - [`ProofOfPossessionKey`] as specified in [section 3.1 of RFC 8747](https://www.rfc-editor.org/rfc/rfc8747#section-3.1).
 //!   For example, this will be used in the access token's `cnf` claim.
 //! - While not really a data type, various constants representing values used in ACE-OAuth
 //!   are provided in the [`constants`](crate::common::constants) module.
@@ -187,12 +187,12 @@
 //! For this reason, the various COSE cipher traits exist; namely,
 //! [`CoseEncrypt0Cipher`], [`CoseSign1Cipher`], and [`CoseMac0Cipher`], each implementing
 //! a corresponding COSE operation as specified in sections 4, 5, and 6 of
-//! [RFC 8152](https://datatracker.ietf.org/doc/html/rfc8152).
+//! [RFC 8152](https://www.rfc-editor.org/rfc/rfc8152).
 //!
 //! Note that these ciphers *don't* need to wrap their results in e.g. a `Cose_Encrypt0` structure,
 //! this part is already handled using this library (which uses [`coset`])---only the
 //! cryptographic algorithms themselves need to be implemented (e.g. step 4 of
-//! "how to decrypt a message" in [section 5.3 of RFC 8152](https://datatracker.ietf.org/doc/html/rfc8152#section-5.3)).
+//! "how to decrypt a message" in [section 5.3 of RFC 8152](https://www.rfc-editor.org/rfc/rfc8152#section-5.3)).
 //!
 //! When implementing any of the specific COSE ciphers, you'll also need to implement the
 //! [`CoseCipherCommon`] trait, which can be used to set headers specific to your COSE cipher
@@ -232,8 +232,8 @@ pub use endpoints::token_req::{
 };
 #[doc(inline)]
 pub use token::{
-    decrypt_access_token, encrypt_access_token, get_token_headers, sign_access_token,
-    verify_access_token, CoseCipherCommon, CoseEncrypt0Cipher, CoseMac0Cipher, CoseSign1Cipher,
+    CoseCipherCommon, CoseEncrypt0Cipher, CoseMac0Cipher, CoseSign1Cipher,
+    decrypt_access_token, encrypt_access_token, get_token_headers, sign_access_token, verify_access_token,
 };
 
 pub mod common;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,8 +232,8 @@ pub use endpoints::token_req::{
 };
 #[doc(inline)]
 pub use token::{
-    CoseCipherCommon, CoseEncrypt0Cipher, CoseMac0Cipher, CoseSign1Cipher,
-    decrypt_access_token, encrypt_access_token, get_token_headers, sign_access_token, verify_access_token,
+    decrypt_access_token, encrypt_access_token, get_token_headers, sign_access_token,
+    verify_access_token, CoseCipherCommon, CoseEncrypt0Cipher, CoseMac0Cipher, CoseSign1Cipher,
 };
 
 pub mod common;


### PR DESCRIPTION
ACE-OAuth, along with its related drafts, has now been released as an RFC.
This pull request updates the documentation and adds the newly specified `CoapOscore` profile.