### PR TITLE
feat: Add support for ACE OSCORE security parameters in cnf

### DIFF
--- a/src/common/cbor_values/mod.rs
+++ b/src/common/cbor_values/mod.rs
@@ -29,7 +29,7 @@
 use core::fmt::{Debug, Display, Formatter};
 use core::ops::Deref;
 
-use coset::{CoseEncrypt0, CoseKey};
+use coset::{CoseEncrypt0, CoseKey, OscoreInputMaterial};
 use strum_macros::IntoStaticStr;
 
 #[cfg(not(feature = "std"))]
@@ -91,6 +91,10 @@ pub enum ProofOfPossessionKey {
     ///
     /// For details, see [section 3.4 of RFC 8747](https://datatracker.ietf.org/doc/html/rfc8747#section-3.4).
     KeyId(KeyId),
+
+    /// OSCORE input material that is used in the ACE OSCORE profile (RFC 9203), in which
+    /// parameters for OSCORE communication are established.
+    OscoreInputMaterial(OscoreInputMaterial),
 }
 
 impl ProofOfPossessionKey {
@@ -117,6 +121,7 @@ impl ProofOfPossessionKey {
                     &k.protected.header.key_id
                 }
             }
+            ProofOfPossessionKey::OscoreInputMaterial(_) => todo!(),
         }
     }
 }
@@ -212,6 +217,7 @@ mod conversion {
                     let x: i128 = 3;
                     vec![(x, Some(Box::new(Value::Bytes(kid.clone()))))]
                 }
+                Self::OscoreInputMaterial(_) => todo!(),
             }
         }
 
@@ -240,6 +246,13 @@ mod conversion {
                             ))
                         }),
                     (3, Value::Bytes(x)) => Ok(ProofOfPossessionKey::KeyId(x)),
+                    (4, m @ Value::Map(_)) => OscoreInputMaterial::from_cbor_value(m)
+                        .map(ProofOfPossessionKey::OscoreInputMaterial)
+                        .map_err(|x| {
+                            TryFromCborMapError::from_message(format!(
+                                "couldn't create OscoreInputMaterial from CBOR value: {x}"
+                            ))
+                        }),
                     (x, _) => Err(TryFromCborMapError::unknown_field(u8::try_from(x)?)),
                 }
             } else {


### PR DESCRIPTION
This builds on https://github.com/google/coset/pull/58, and is in itself rather incomplete; still pushing it here for tracking, and CC'ing @falko17 due to earlier work on OSCORE support in this crate (of which I don't quite see how it was used without this).