### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] --- 2023-03-27
 
 This release mainly adds support for multiple token recipients, deals with the newly released RFCs,
-and fixes `no_std` support.
+and fixes `no_std` support. 
 Note that the cipher interfaces have been refactored in a major way.
 
 ### Added
@@ -131,7 +131,9 @@ For more extensive documentation, consult the
 
 [0.3.1]: https://github.com/namib-project/dcaf-rs/compare/v0.3.0...v0.3.1
 
-[Unreleased]: https://github.com/namib-project/dcaf-rs/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/namib-project/dcaf-rs/compare/v0.3.1...v0.4.0
+
+[Unreleased]: https://github.com/namib-project/dcaf-rs/compare/v0.4.0...HEAD
 
 [AIF]: https://www.rfc-editor.org/rfc/rfc9237.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,3 @@ rand = { version = "^0.8", default-features = false }
 
 [dev-dependencies]
 hex = { version = "^0.4" }
-base64 = { version = "^0.13" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ciborium-io = { version = "^0.2", default-features = false }
 coset = { version = "^0.3", default-features = false }
 serde_bytes = { version = "^0.11", default-features = false, features = ["alloc"] }
 erased-serde = { version = "^0.3", default-features = false, features = ["alloc"] }
-derive_builder = { version = "^0.11", default-features = false }
+derive_builder = { version = "^0.12", default-features = false }
 strum = { version = "^0.24", default-features = false, features = ["derive"] }
 strum_macros = { version = "^0.24", default-features = false }
 enumflags2 = { version = "^0.7", default-features = false }

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ requirements are minimal---as such, while `alloc` is still needed, this crate of
 ## Usage
 ```toml
 [dependencies]
-dcaf = { version = "^0.3" }
+dcaf = { version = "^0.4" }
 ```
 Or, if you plan to use this crate in a `no_std` environment:
 ```toml
 [dependencies]
-dcaf = { version = "^0.3", default-features = false }
+dcaf = { version = "^0.4", default-features = false }
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ let request = AccessTokenRequest::builder()
    .client_id("myclient")
    .audience("valve242")
    .scope(TextEncodedScope::try_from("read")?)
-   .req_cnf(ProofOfPossessionKey::KeyId(base64::decode("6kg0dXJM13U")?))
+   .req_cnf(ProofOfPossessionKey::KeyId(hex::decode("ea483475724cd775")?))
    .build()?;
 let mut encoded = Vec::new();
 request.clone().serialize_into(&mut encoded)?;

--- a/src/common/test_helper.rs
+++ b/src/common/test_helper.rs
@@ -163,7 +163,7 @@ impl CoseEncryptCipher for FakeCrypto {
     ) -> Result<Vec<u8>, CoseCipherError<Self::Error>> {
         // Now we just split off the AAD and key we previously put at the end of the data.
         // We return an error if it does not match.
-        if &key.key_id != &protected_header.header.key_id {
+        if key.key_id != protected_header.header.key_id {
             // Mismatching key
             return Err(CoseCipherError::DecryptionFailure);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //!    .client_id("myclient")
 //!    .audience("valve242")
 //!    .scope(TextEncodedScope::try_from("read")?)
-//!    .req_cnf(ProofOfPossessionKey::KeyId(base64::decode("6kg0dXJM13U")?))
+//!    .req_cnf(ProofOfPossessionKey::KeyId(hex::decode("ea483475724cd775")?))
 //!    .build()?;
 //! let mut encoded = Vec::new();
 //! request.clone().serialize_into(&mut encoded)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,12 +42,12 @@
 //! # Usage
 //! ```toml
 //! [dependencies]
-//! dcaf = { version = "^0.3" }
+//! dcaf = { version = "^0.4" }
 //! ```
 //! Or, if you plan to use this crate in a `no_std` environment:
 //! ```toml
 //! [dependencies]
-//! dcaf = { version = "^0.3", default-features = false }
+//! dcaf = { version = "^0.4", default-features = false }
 //! ```
 //!
 //! # Example


### PR DESCRIPTION
- README and crate-level docs have been modified to refer to the new 0.4.0 version.
- `derive_builder` dependency was updated, and `base64` dependency was removed (the place where a base64-encoded string has been used was replaced with a hexadecimal-encoded string).
- One new clippy warning has been addressed (comparison of references replaced with direct comparison).

After this PR is merged, version 0.4.0 will be released.