### PR TITLE
Add support for ChaCha20/Poly1305

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustc, cargo
-      - run: cargo test --no-default-features --features openssl
+      - run: cargo test --no-default-features --features openssl,rustcrypto
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,13 @@ exclude = [
 default = ["std", "openssl"]
 std = ["serde/std", "ciborium/std", "serde_bytes/std", "erased-serde/std", "derive_builder/std"]
 rustcrypto = ["rustcrypto-aes-gcm", "rustcrypto-aes-kw", "rustcrypto-ecdsa", "rustcrypto-hmac"]
-rustcrypto-encrypt = ["rustcrypto-aes-gcm", "rustcrypto-aes-ccm"]
+rustcrypto-encrypt = ["rustcrypto-aes-gcm", "rustcrypto-aes-ccm", "rustcrypto-chacha20-poly1305"]
 rustcrypto-sign = ["rustcrypto-ecdsa"]
 rustcrypto-key-distribution = ["rustcrypto-aes-kw"]
 rustcrypto-mac = ["rustcrypto-hmac"]
 rustcrypto-aes-gcm = ["dep:aes-gcm", "dep:typenum", "dep:aead", "dep:aes"]
 rustcrypto-aes-ccm = ["dep:ccm", "dep:typenum", "dep:aead", "dep:aes"]
+rustcrypto-chacha20-poly1305 = ["dep:chacha20poly1305", "dep:typenum", "dep:aead"]
 rustcrypto-aes-kw = ["dep:aes-kw", "dep:aes", "dep:typenum", "dep:crypto-common"]
 rustcrypto-ecdsa = ["dep:ecdsa", "dep:p256", "dep:p384", "dep:digest", "dep:sha2", "dep:elliptic-curve"]
 rustcrypto-hmac = ["dep:hmac", "dep:digest", "dep:sha2"]
@@ -43,6 +44,7 @@ openssl = { version = "^0.10", optional = true }
 lazy_static = "1.4.0"
 aes-gcm = { version = "0.10.3", optional = true, default-features = false, features = ["alloc", "aes"] }
 ccm = { version = "0.5.0", optional = true, default-features = false, features = ["alloc"] }
+chacha20poly1305 = { version = "0.10.1", optional = true, default-features = false, features = ["alloc"] }
 typenum = { version = "1.17.0", optional = true, default-features = false, features = ["const-generics"] }
 crypto-common = { version = "0.1.6", optional = true, default-features = false }
 aead = { version = "0.5.2", optional = true, default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,9 @@ fn main() {
     cfg_aliases! {
         rustcrypto_encrypt_base: {
             any(
-                feature = "rustcrypto-aes-gcm"
+                feature = "rustcrypto-aes-gcm",
+                feature = "rustcrypto-aes-ccm",
+                feature = "rustcrypto-chacha20-poly1305"
             )
         },
         rustcrypto_sign_base: {

--- a/src/token/cose/crypto_impl/rustcrypto/encrypt/aead.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/encrypt/aead.rs
@@ -16,6 +16,7 @@ use crate::error::CoseCipherError;
 use crate::token::cose::{CoseSymmetricKey, CryptoBackend};
 
 use super::RustCryptoContext;
+use alloc::vec::Vec;
 
 impl<RNG: RngCore + CryptoRng> RustCryptoContext<RNG> {
     /// Perform an AEAD encryption operation on `plaintext` and the additional authenticated

--- a/src/token/cose/crypto_impl/rustcrypto/encrypt/aes_ccm.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/encrypt/aes_ccm.rs
@@ -19,6 +19,7 @@ use crate::error::CoseCipherError;
 use crate::token::cose::{CoseSymmetricKey, CryptoBackend};
 
 use super::RustCryptoContext;
+use alloc::vec::Vec;
 
 impl<RNG: RngCore + CryptoRng> RustCryptoContext<RNG> {
     /// Perform an AES-CCM encryption operation on `plaintext` and the additional authenticated

--- a/src/token/cose/crypto_impl/rustcrypto/encrypt/aes_gcm.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/encrypt/aes_gcm.rs
@@ -19,6 +19,7 @@ use crate::error::CoseCipherError;
 use crate::token::cose::{CoseSymmetricKey, CryptoBackend};
 
 use super::RustCryptoContext;
+use alloc::vec::Vec;
 
 impl<RNG: RngCore + CryptoRng> RustCryptoContext<RNG> {
     /// Perform an AES-GCM encryption operation on `plaintext` and the additional authenticated

--- a/src/token/cose/crypto_impl/rustcrypto/encrypt/chacha_poly.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/encrypt/chacha_poly.rs
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 The NAMIB Project Developers.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+use crate::error::CoseCipherError;
+use crate::token::cose::crypto_impl::rustcrypto::RustCryptoContext;
+use crate::token::cose::{CoseSymmetricKey, CryptoBackend};
+use alloc::vec::Vec;
+use chacha20poly1305::ChaCha20Poly1305;
+use rand::CryptoRng;
+use rand::RngCore;
+
+impl<RNG: RngCore + CryptoRng> RustCryptoContext<RNG> {
+    /// Perform a ChaCha20/Poly1305 encryption operation on `plaintext` and the additional
+    /// authenticated data `aad` using the given `iv` and `key`.
+    pub(super) fn encrypt_chacha20_poly1305(
+        key: &CoseSymmetricKey<'_, <Self as CryptoBackend>::Error>,
+        plaintext: &[u8],
+        aad: &[u8],
+        iv: &[u8],
+    ) -> Result<Vec<u8>, CoseCipherError<<Self as CryptoBackend>::Error>> {
+        Self::encrypt_aead::<ChaCha20Poly1305>(key, plaintext, aad, iv)
+    }
+
+    /// Perform a ChaCha20/Poly1305 decryption operation on `ciphertext_with_tag` and the additional
+    /// authenticated data `aad` using the given `iv` and `key`.
+    pub(super) fn decrypt_chacha20_poly1305(
+        key: &CoseSymmetricKey<'_, <Self as CryptoBackend>::Error>,
+        ciphertext_with_tag: &[u8],
+        aad: &[u8],
+        iv: &[u8],
+    ) -> Result<Vec<u8>, CoseCipherError<<Self as CryptoBackend>::Error>> {
+        Self::decrypt_aead::<ChaCha20Poly1305>(key, ciphertext_with_tag, aad, iv)
+    }
+}

--- a/src/token/cose/crypto_impl/rustcrypto/key_distribution/aes_key_wrap.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/key_distribution/aes_key_wrap.rs
@@ -20,6 +20,7 @@ use crate::error::CoseCipherError;
 use crate::token::cose::{CoseSymmetricKey, CryptoBackend};
 
 use super::RustCryptoContext;
+use alloc::vec::Vec;
 
 impl<RNG: RngCore + CryptoRng> RustCryptoContext<RNG> {
     /// Perform an AES key wrap operation on the key contained in `plaintext` which is wrapped

--- a/src/token/cose/crypto_impl/rustcrypto/key_distribution/mod.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/key_distribution/mod.rs
@@ -14,6 +14,7 @@ use rand::{CryptoRng, RngCore};
 use crate::error::CoseCipherError;
 use crate::token::cose::crypto_impl::rustcrypto::RustCryptoContext;
 use crate::token::cose::{CoseSymmetricKey, KeyDistributionCryptoBackend};
+use alloc::vec::Vec;
 
 #[cfg(feature = "rustcrypto-aes-kw")]
 mod aes_key_wrap;

--- a/src/token/cose/crypto_impl/rustcrypto/mac/hmac.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/mac/hmac.rs
@@ -17,6 +17,7 @@ use sha2::{Sha256, Sha384, Sha512};
 use crate::error::CoseCipherError;
 use crate::token::cose::crypto_impl::rustcrypto::RustCryptoContext;
 use crate::token::cose::{CoseSymmetricKey, CryptoBackend};
+use alloc::vec::Vec;
 
 impl<RNG: RngCore + CryptoRng> RustCryptoContext<RNG> {
     /// Compute the HMAC of `payload` using the given `key` with the HMAC function

--- a/src/token/cose/crypto_impl/rustcrypto/mac/mod.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/mac/mod.rs
@@ -13,6 +13,7 @@ use crate::token::cose::crypto_impl::rustcrypto::CoseCipherError;
 use crate::token::cose::crypto_impl::rustcrypto::RustCryptoContext;
 use crate::token::cose::CoseSymmetricKey;
 use crate::token::cose::MacCryptoBackend;
+use alloc::vec::Vec;
 use coset::iana;
 use rand::{CryptoRng, RngCore};
 

--- a/src/token/cose/crypto_impl/rustcrypto/mod.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/mod.rs
@@ -92,7 +92,11 @@ impl From<digest::MacError> for CoseCipherError<CoseRustCryptoCipherError> {
     }
 }
 
-#[cfg(feature = "rustcrypto-aes-gcm")]
+#[cfg(any(
+    feature = "rustcrypto-aes-gcm",
+    feature = "rustcrypto-aes-ccm",
+    feature = "rustcrypto-chacha20-poly1305"
+))]
 impl From<aead::Error> for CoseCipherError<CoseRustCryptoCipherError> {
     fn from(_value: aead::Error) -> Self {
         CoseCipherError::VerificationFailure

--- a/src/token/cose/crypto_impl/rustcrypto/sign/ecdsa.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/sign/ecdsa.rs
@@ -33,6 +33,7 @@ use crate::error::CoseCipherError;
 use crate::token::cose::crypto_impl::rustcrypto::CoseRustCryptoCipherError;
 use crate::token::cose::crypto_impl::rustcrypto::RustCryptoContext;
 use crate::token::cose::{CoseEc2Key, CryptoBackend, EllipticCurve};
+use alloc::vec::Vec;
 
 impl<RNG: RngCore + CryptoRng> RustCryptoContext<RNG> {
     /// Perform an ECDSA signature operation with the ECDSA variant given in `algorithm` for the

--- a/src/token/cose/crypto_impl/rustcrypto/sign/mod.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/sign/mod.rs
@@ -15,6 +15,7 @@ use rand::{CryptoRng, RngCore};
 
 use crate::token::cose::crypto_impl::rustcrypto::RustCryptoContext;
 use crate::token::SignCryptoBackend;
+use alloc::vec::Vec;
 
 #[cfg(feature = "rustcrypto-ecdsa")]
 mod ecdsa;

--- a/src/token/cose/encrypted/encrypt/tests.rs
+++ b/src/token/cose/encrypted/encrypt/tests.rs
@@ -32,7 +32,11 @@ use crate::token::cose::{util::determine_header_param, CryptoBackend};
 #[cfg(feature = "openssl")]
 use crate::token::cose::test_helper::openssl_ctx;
 #[cfg(all(
-    any(feature = "rustcrypto-aes-gcm", feature = "rustcrypto-aes-ccm"),
+    any(
+        feature = "rustcrypto-aes-gcm",
+        feature = "rustcrypto-aes-ccm",
+        feature = "rustcrypto-chacha20-poly1305"
+    ),
     feature = "rustcrypto-aes-kw"
 ))]
 use crate::token::cose::test_helper::rustcrypto_ctx;
@@ -320,6 +324,42 @@ fn cose_examples_aes_ccm_self_signed<B: EncryptCryptoBackend + KeyDistributionCr
 #[rstest]
 #[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
 #[cfg_attr(
+    all(
+        feature = "rustcrypto-aes-kw",
+        feature = "rustcrypto-chacha20-poly1305"
+    ),
+    case::rustcrypto(rustcrypto_ctx())
+)]
+fn cose_examples_chacha20_poly1305_reference_output<
+    B: EncryptCryptoBackend + KeyDistributionCryptoBackend,
+>(
+    #[files("tests/cose_examples/chacha-poly-examples/chacha-poly-0[0-9].json")] test_path: PathBuf,
+    #[case] backend: B,
+) {
+    perform_cose_reference_output_test::<CoseEncrypt, B>(test_path, backend);
+}
+
+#[rstest]
+#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
+#[cfg_attr(
+    all(
+        feature = "rustcrypto-aes-kw",
+        feature = "rustcrypto-chacha20-poly1305"
+    ),
+    case::rustcrypto(rustcrypto_ctx())
+)]
+fn cose_examples_chacha20_poly1305_self_signed<
+    B: EncryptCryptoBackend + KeyDistributionCryptoBackend,
+>(
+    #[files("tests/cose_examples/chacha-poly-examples/chacha-poly-0[0-9].json")] test_path: PathBuf,
+    #[case] backend: B,
+) {
+    perform_cose_self_signed_test::<CoseEncrypt, B>(test_path, backend);
+}
+
+#[rstest]
+#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
+#[cfg_attr(
     all(feature = "rustcrypto-aes-kw", feature = "rustcrypto-aes-gcm"),
     case::rustcrypto(rustcrypto_ctx())
 )]
@@ -351,6 +391,22 @@ fn aes_gcm_tests<B: EncryptCryptoBackend + KeyDistributionCryptoBackend>(
 )]
 fn aes_ccm_tests<B: EncryptCryptoBackend + KeyDistributionCryptoBackend>(
     #[files("tests/dcaf_cose_examples/aes-ccm/*.json")] test_path: PathBuf,
+    #[case] backend: B,
+) {
+    perform_cose_self_signed_test::<CoseEncrypt, B>(test_path, backend);
+}
+
+#[rstest]
+#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
+#[cfg_attr(
+    all(
+        feature = "rustcrypto-aes-kw",
+        feature = "rustcrypto-chacha20-poly1305"
+    ),
+    case::rustcrypto(rustcrypto_ctx())
+)]
+fn chacha20_poly1305_tests<B: EncryptCryptoBackend + KeyDistributionCryptoBackend>(
+    #[files("tests/dcaf_cose_examples/chacha-poly/*.json")] test_path: PathBuf,
     #[case] backend: B,
 ) {
     perform_cose_self_signed_test::<CoseEncrypt, B>(test_path, backend);

--- a/src/token/cose/encrypted/encrypt0/tests.rs
+++ b/src/token/cose/encrypted/encrypt0/tests.rs
@@ -24,7 +24,11 @@ use crate::token::cose::CryptoBackend;
 
 #[cfg(feature = "openssl")]
 use crate::token::cose::test_helper::openssl_ctx;
-#[cfg(any(feature = "rustcrypto-aes-gcm", feature = "rustcrypto-aes-ccm"))]
+#[cfg(any(
+    feature = "rustcrypto-aes-gcm",
+    feature = "rustcrypto-aes-ccm",
+    feature = "rustcrypto-chacha20-poly1305"
+))]
 use crate::token::cose::test_helper::rustcrypto_ctx;
 
 impl<B: CryptoBackend + EncryptCryptoBackend> CoseStructTestHelper<B> for CoseEncrypt0 {
@@ -184,6 +188,32 @@ fn cose_examples_aes_ccm_encrypt0_reference_output<B: EncryptCryptoBackend>(
 #[cfg_attr(feature = "rustcrypto-aes-ccm", case::rustcrypto(rustcrypto_ctx()))]
 fn cose_examples_aes_ccm_encrypt0_self_signed<B: EncryptCryptoBackend>(
     #[files("tests/cose_examples/aes-ccm-examples/aes-ccm-enc-*.json")] test_path: PathBuf,
+    #[case] backend: B,
+) {
+    perform_cose_self_signed_test::<CoseEncrypt0, B>(test_path, backend);
+}
+
+#[rstest]
+#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
+#[cfg_attr(
+    feature = "rustcrypto-chacha20-poly1305",
+    case::rustcrypto(rustcrypto_ctx())
+)]
+fn cose_examples_chacha20_poly1305_reference_output<B: EncryptCryptoBackend>(
+    #[files("tests/cose_examples/chacha-poly-examples/chacha-poly-enc-*.json")] test_path: PathBuf,
+    #[case] backend: B,
+) {
+    perform_cose_reference_output_test::<CoseEncrypt0, B>(test_path, backend);
+}
+
+#[rstest]
+#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
+#[cfg_attr(
+    feature = "rustcrypto-chacha20-poly1305",
+    case::rustcrypto(rustcrypto_ctx())
+)]
+fn cose_examples_chacha20_poly1305_self_signed<B: EncryptCryptoBackend>(
+    #[files("tests/cose_examples/chacha-poly-examples/chacha-poly-enc-*.json")] test_path: PathBuf,
     #[case] backend: B,
 ) {
     perform_cose_self_signed_test::<CoseEncrypt0, B>(test_path, backend);

--- a/src/token/cose/header.rs
+++ b/src/token/cose/header.rs
@@ -1,5 +1,5 @@
 use crate::error::CoseCipherError;
-use crate::token::cose::util::aes_algorithm_iv_len;
+use crate::token::cose::util::symmetric_algorithm_iv_len;
 use crate::token::cose::{CryptoBackend, EncryptCryptoBackend};
 use coset::{iana, HeaderBuilder};
 
@@ -25,7 +25,7 @@ impl HeaderBuilderExt for HeaderBuilder {
         backend: &mut B,
         alg: iana::Algorithm,
     ) -> Result<Self, CoseCipherError<B::Error>> {
-        let iv_size = aes_algorithm_iv_len(alg)?;
+        let iv_size = symmetric_algorithm_iv_len(alg)?;
         let mut iv = vec![0; iv_size];
         backend.generate_rand(&mut iv)?;
         Ok(self.iv(iv))

--- a/src/token/cose/recipient/mod.rs
+++ b/src/token/cose/recipient/mod.rs
@@ -25,7 +25,7 @@ use crate::token::cose::aad::{AadProvider, InvertedAadProvider};
 use crate::token::cose::header::HeaderParam;
 use crate::token::cose::key::{CoseParsedKey, KeyProvider};
 use crate::token::cose::util::determine_header_param;
-use crate::token::cose::util::ensure_valid_aes_key;
+use crate::token::cose::util::ensure_valid_symmetric_key;
 use crate::token::cose::util::try_cose_crypto_operation;
 use crate::token::cose::util::{determine_algorithm, determine_key_candidates};
 use crate::token::cose::{CoseSymmetricKey, CryptoBackend};
@@ -612,7 +612,7 @@ impl CoseRecipientBuilderExt for CoseRecipientBuilder {
                             iana::Algorithm::A128KW
                             | iana::Algorithm::A192KW
                             | iana::Algorithm::A256KW => {
-                                let symm_key = ensure_valid_aes_key(alg, parsed_key)?;
+                                let symm_key = ensure_valid_symmetric_key(alg, parsed_key)?;
 
                                 if protected.is_some() && !protected.as_ref().unwrap().is_empty() {
                                     return Err(CoseCipherError::AadUnsupported);
@@ -842,7 +842,7 @@ impl CoseRecipientExt for CoseRecipient {
                         iana::Algorithm::A128KW
                         | iana::Algorithm::A192KW
                         | iana::Algorithm::A256KW => {
-                            let symm_key = ensure_valid_aes_key(alg, parsed_key)?;
+                            let symm_key = ensure_valid_symmetric_key(alg, parsed_key)?;
                             if !self.protected.is_empty() {
                                 return Err(CoseCipherError::AadUnsupported);
                             }

--- a/src/token/cose/test_helper.rs
+++ b/src/token/cose/test_helper.rs
@@ -117,6 +117,7 @@ fn string_to_algorithm<'de, D: Deserializer<'de>>(
         Some("A128GCM") => Ok(Some(iana::Algorithm::A128GCM)),
         Some("A192GCM") => Ok(Some(iana::Algorithm::A192GCM)),
         Some("A256GCM") => Ok(Some(iana::Algorithm::A256GCM)),
+        Some("ChaCha-Poly1305") => Ok(Some(iana::Algorithm::ChaCha20Poly1305)),
         Some("AES-CCM-16-128/64") => Ok(Some(iana::Algorithm::AES_CCM_16_64_128)),
         Some("AES-CCM-16-256/64") => Ok(Some(iana::Algorithm::AES_CCM_16_64_256)),
         Some("AES-CCM-64-128/64") => Ok(Some(iana::Algorithm::AES_CCM_64_64_128)),

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -12,7 +12,7 @@
 use super::*;
 use crate::common::test_helper::MockCipher;
 use crate::error::CoseCipherError;
-use crate::token::cose::util::aes_algorithm_iv_len;
+use crate::token::cose::util::symmetric_algorithm_iv_len;
 use alloc::vec::Vec;
 use alloc::{string::ToString, vec};
 use base64::Engine;
@@ -88,7 +88,7 @@ fn example_headers(alg: Algorithm, generate_iv: bool) -> (Header, Header) {
         let mut iv = vec![
             0x63, 0x68, 0x98, 0x99, 0x4F, 0xF0, 0xEC, 0x7B, 0xFC, 0xF6, 0xD3, 0xF9, 0x5B,
         ];
-        iv.truncate(aes_algorithm_iv_len::<Infallible>(alg).expect("invalid algorithm"));
+        iv.truncate(symmetric_algorithm_iv_len::<Infallible>(alg).expect("invalid algorithm"));
         unprotected_header_builder = unprotected_header_builder.iv(iv);
     }
     let unprotected_header = unprotected_header_builder.build();

--- a/tests/dcaf_cose_examples/chacha-poly/empty_payload.json
+++ b/tests/dcaf_cose_examples/chacha-poly/empty_payload.json
@@ -1,0 +1,36 @@
+{
+  "title": "ChaCha-Poly1305-01: Encryption with empty payload",
+  "input": {
+    "plaintext": "",
+    "enveloped": {
+      "protected": {
+        "alg": "ChaCha-Poly1305"
+      },
+      "recipients": [
+        {
+          "key": {
+            "kty": "oct",
+            "kid": "sec-256",
+            "use": "enc",
+            "k": "Dx4tPEtaaXiHlqW0w9Lh8B8uPUxbanmIl6a1xNPi8QA"
+          },
+          "unprotected": {
+            "alg": "direct",
+            "kid": "sec-256"
+          }
+        }
+      ]
+    },
+    "rng_stream": [
+      "26682306D4FB28CA01B43B80"
+    ]
+  },
+  "intermediates": {
+    "AAD_hex": "8367456E637279707444A101181840",
+    "CEK_hex": "0F1E2D3C4B5A69788796A5B4C3D2E1F01F2E3D4C5B6A798897A6B5C4D3E2F100",
+    "recipients": [
+      {
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Just like #24, just for ChaCha20/Poly1305.

Also solves some minor issues with imports in `no_std` environments using the RustCrypto backend and ensures the pipeline also tests rustcrypto with `no_std`.

Depends on #25.
Closes #18.