### PR TITLE
ci: update grcov to latest stable version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,19 +95,20 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          components: rustc, rust-std, cargo, llvm-tools
+          components: rustc, rust-std, cargo, llvm-tools, llvm-tools-preview
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: grcov
       - run: cargo clean
+      - run: mkdir -p ./target/debug/coverage
       - run: cargo test --all-features --no-fail-fast
         env:
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-      - run: mkdir ./target/debug/coverage
-      - run: zip ./target/debug/coverage/files.zip ./target/debug/deps/dcaf-*.gcda ./target/debug/deps/dcaf-*.gcno
-      - run: grcov ./target/debug/coverage/files.zip -s . --service-name "Continuous Integration" --commit-sha ${GITHUB_SHA} -t coveralls --branch --ignore-not-existing --ignore "../*" --ignore "/*" --ignore "*/test_helper.rs" -o ./target/debug/coverage/ --token=${COVERALLS_TOKEN}
+          LLVM_PROFILE_FILE: 'target/debug/coverage/dcaf-%p-%m.profraw'
+          RUSTFLAGS: '-Cinstrument-coverage -Cpanic=abort -Zpanic_abort_tests'
+          RUSTDOCFLAGS: '-C instrument-coverage -Cpanic=abort -Zpanic_abort_tests -Z unstable-options --persist-doctests target/debug/'
+      - run: zip ./target/debug/coverage/files.zip ./target/debug/coverage/dcaf-*.profraw
+      - run: grcov ./target/debug/coverage/files.zip -s . --binary-path ./target/debug/ --service-name "Continuous Integration" --commit-sha ${GITHUB_SHA} -t coveralls --branch --ignore-not-existing --ignore "../*" --ignore "/*" --ignore "*/test_helper.rs" -o ./target/debug/coverage/ --token=${COVERALLS_TOKEN}
       - name: Coveralls upload
         uses: coverallsapp/github-action@main
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -99,10 +99,6 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: grcov
-          # grcov currently has some compilation issues on newer rust versions due to an outdated dependency.
-          # This pulls in the branch from https://github.com/mozilla/grcov/pull/1191 in order to fix this.
-          git: https://github.com/cemoktra/grcov.git
-          branch: cemoktra/fix-1187
       - run: cargo clean
       - run: cargo test --all-features --no-fail-fast
         env:


### PR DESCRIPTION
The new stable release of grcov fixes the compilation issue related to the `time` crate, which we previously worked around by pulling in the branch from mozilla/grcov#1191.

Therefore, our previous workaround is no longer necessary, and we can use the stable version again.