### PR TITLE
Add support for HMAC 256/64 to COSE module

### DIFF
--- a/src/token/cose/crypto_impl/openssl/mac.rs
+++ b/src/token/cose/crypto_impl/openssl/mac.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 The NAMIB Project Developers.
+ * Copyright (c) 2022-2025 The NAMIB Project Developers.
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
  * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -24,10 +24,17 @@ fn compute_hmac(
     input: &[u8],
 ) -> Result<Vec<u8>, CoseCipherError<CoseOpensslCipherError>> {
     let hash = super::get_algorithm_hash_function(algorithm)?;
+    let truncation_len = super::get_algorithm_hash_truncation(algorithm)?;
     let hmac_key = PKey::hmac(key.k)?;
     let mut signer = Signer::new(hash, &hmac_key)?;
     signer
         .sign_oneshot_to_vec(input)
+        .map(|mut v| {
+            if let Some(truncation_len) = truncation_len {
+                v.truncate(truncation_len);
+            }
+            v
+        })
         .map_err(CoseCipherError::from)
 }
 

--- a/src/token/cose/crypto_impl/rustcrypto/mod.rs
+++ b/src/token/cose/crypto_impl/rustcrypto/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 The NAMIB Project Developers.
+ * Copyright (c) 2024-2025 The NAMIB Project Developers.
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
  * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -128,7 +128,7 @@ impl From<ecdsa::Error> for CoseCipherError<CoseRustCryptoCipherError> {
 ///     - [ ] EdDSA
 /// - Message Authentication Code Algorithms (for COSE_Mac and COSE_Mac0)
 ///     - [x] HMAC
-///         - [ ] HMAC 256/64
+///         - [x] HMAC 256/64
 ///         - [x] HMAC 256/256
 ///         - [x] HMAC 384/384
 ///         - [x] HMAC 512/512

--- a/src/token/cose/maced/mac/mod.rs
+++ b/src/token/cose/maced/mac/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 The NAMIB Project Developers.
+ * Copyright (c) 2024-2025 The NAMIB Project Developers.
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
  * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/src/token/cose/maced/mac/tests.rs
+++ b/src/token/cose/maced/mac/tests.rs
@@ -186,7 +186,7 @@ fn cose_examples_mac_self_signed<B: MacCryptoBackend + KeyDistributionCryptoBack
     case::rustcrypto(rustcrypto_ctx())
 )]
 fn cose_examples_hmac_mac_reference_output<B: MacCryptoBackend + KeyDistributionCryptoBackend>(
-    #[files("tests/cose_examples/hmac-examples/HMac-0[0-4].json")] test_path: PathBuf,
+    #[files("tests/cose_examples/hmac-examples/HMac-0[0-5].json")] test_path: PathBuf,
     #[case] backend: B,
 ) {
     test_helper::perform_cose_reference_output_test::<CoseMac, B>(test_path, backend);
@@ -199,37 +199,7 @@ fn cose_examples_hmac_mac_reference_output<B: MacCryptoBackend + KeyDistribution
     case::rustcrypto(rustcrypto_ctx())
 )]
 fn cose_examples_hmac_mac_self_signed<B: MacCryptoBackend + KeyDistributionCryptoBackend>(
-    #[files("tests/cose_examples/hmac-examples/HMac-0[0-4].json")] test_path: PathBuf,
-    #[case] backend: B,
-) {
-    test_helper::perform_cose_self_signed_test::<CoseMac, B>(test_path, backend);
-}
-
-// As of now, RustCrypto does not support HMAC 256/64, so we must only perform this test with
-// OpenSSL.
-//
-// Once RustCrypto supports this algorithm, we can merge this test with
-// cose_examples_hmac_mac_reference_output.
-#[rstest]
-#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
-fn cose_examples_hmac256_64_mac_reference_output<
-    B: MacCryptoBackend + KeyDistributionCryptoBackend,
->(
-    #[files("tests/cose_examples/hmac-examples/HMac-05.json")] test_path: PathBuf,
-    #[case] backend: B,
-) {
-    test_helper::perform_cose_reference_output_test::<CoseMac, B>(test_path, backend);
-}
-
-// As of now, RustCrypto does not support HMAC 256/64, so we must only perform this test with
-// OpenSSL.
-//
-// Once RustCrypto supports this algorithm, we can merge this test with
-// cose_examples_hmac_mac_self_signed.
-#[rstest]
-#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
-fn cose_examples_hmac256_64_mac_self_signed<B: MacCryptoBackend + KeyDistributionCryptoBackend>(
-    #[files("tests/cose_examples/hmac-examples/HMac-05.json")] test_path: PathBuf,
+    #[files("tests/cose_examples/hmac-examples/HMac-0[0-5].json")] test_path: PathBuf,
     #[case] backend: B,
 ) {
     test_helper::perform_cose_self_signed_test::<CoseMac, B>(test_path, backend);

--- a/src/token/cose/maced/mac/tests.rs
+++ b/src/token/cose/maced/mac/tests.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 The NAMIB Project Developers.
+ * Copyright (c) 2024-2025 The NAMIB Project Developers.
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
  * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -200,6 +200,36 @@ fn cose_examples_hmac_mac_reference_output<B: MacCryptoBackend + KeyDistribution
 )]
 fn cose_examples_hmac_mac_self_signed<B: MacCryptoBackend + KeyDistributionCryptoBackend>(
     #[files("tests/cose_examples/hmac-examples/HMac-0[0-4].json")] test_path: PathBuf,
+    #[case] backend: B,
+) {
+    test_helper::perform_cose_self_signed_test::<CoseMac, B>(test_path, backend);
+}
+
+// As of now, RustCrypto does not support HMAC 256/64, so we must only perform this test with
+// OpenSSL.
+//
+// Once RustCrypto supports this algorithm, we can merge this test with
+// cose_examples_hmac_mac_reference_output.
+#[rstest]
+#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
+fn cose_examples_hmac256_64_mac_reference_output<
+    B: MacCryptoBackend + KeyDistributionCryptoBackend,
+>(
+    #[files("tests/cose_examples/hmac-examples/HMac-05.json")] test_path: PathBuf,
+    #[case] backend: B,
+) {
+    test_helper::perform_cose_reference_output_test::<CoseMac, B>(test_path, backend);
+}
+
+// As of now, RustCrypto does not support HMAC 256/64, so we must only perform this test with
+// OpenSSL.
+//
+// Once RustCrypto supports this algorithm, we can merge this test with
+// cose_examples_hmac_mac_self_signed.
+#[rstest]
+#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
+fn cose_examples_hmac256_64_mac_self_signed<B: MacCryptoBackend + KeyDistributionCryptoBackend>(
+    #[files("tests/cose_examples/hmac-examples/HMac-05.json")] test_path: PathBuf,
     #[case] backend: B,
 ) {
     test_helper::perform_cose_self_signed_test::<CoseMac, B>(test_path, backend);

--- a/src/token/cose/maced/mac0/tests.rs
+++ b/src/token/cose/maced/mac0/tests.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 The NAMIB Project Developers.
+ * Copyright (c) 2024-2025 The NAMIB Project Developers.
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
  * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -175,6 +175,34 @@ fn cose_examples_hmac_mac0_reference_output<B: MacCryptoBackend>(
 #[cfg_attr(feature = "rustcrypto-hmac", case::rustcrypto(rustcrypto_ctx()))]
 fn cose_examples_hmac_mac0_self_signed<B: MacCryptoBackend>(
     #[files("tests/cose_examples/hmac-examples/HMac-enc-0[0-4].json")] test_path: PathBuf,
+    #[case] backend: B,
+) {
+    test_helper::perform_cose_self_signed_test::<CoseMac0, B>(test_path, backend);
+}
+
+// As of now, RustCrypto does not support HMAC 256/64, so we must only perform this test with
+// OpenSSL.
+//
+// Once RustCrypto supports this algorithm, we can merge this test with
+// cose_examples_hmac_mac0_reference_output.
+#[rstest]
+#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
+fn cose_examples_hmac256_64_mac0_reference_output<B: MacCryptoBackend>(
+    #[files("tests/cose_examples/hmac-examples/HMac-enc-05.json")] test_path: PathBuf,
+    #[case] backend: B,
+) {
+    test_helper::perform_cose_reference_output_test::<CoseMac0, B>(test_path, backend);
+}
+
+// As of now, RustCrypto does not support HMAC 256/64, so we must only perform this test with
+// OpenSSL.
+//
+// Once RustCrypto supports this algorithm, we can merge this test with
+// cose_examples_hmac_mac0_self_signed.
+#[rstest]
+#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
+fn cose_examples_hmac256_64_mac0_self_signed<B: MacCryptoBackend>(
+    #[files("tests/cose_examples/hmac-examples/HMac-enc-05.json")] test_path: PathBuf,
     #[case] backend: B,
 ) {
     test_helper::perform_cose_self_signed_test::<CoseMac0, B>(test_path, backend);

--- a/src/token/cose/maced/mac0/tests.rs
+++ b/src/token/cose/maced/mac0/tests.rs
@@ -164,7 +164,7 @@ fn cose_examples_mac0_self_signed<B: MacCryptoBackend>(
 #[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
 #[cfg_attr(feature = "rustcrypto-hmac", case::rustcrypto(rustcrypto_ctx()))]
 fn cose_examples_hmac_mac0_reference_output<B: MacCryptoBackend>(
-    #[files("tests/cose_examples/hmac-examples/HMac-enc-0[0-4].json")] test_path: PathBuf,
+    #[files("tests/cose_examples/hmac-examples/HMac-enc-0[0-5].json")] test_path: PathBuf,
     #[case] backend: B,
 ) {
     test_helper::perform_cose_reference_output_test::<CoseMac0, B>(test_path, backend);
@@ -174,35 +174,7 @@ fn cose_examples_hmac_mac0_reference_output<B: MacCryptoBackend>(
 #[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
 #[cfg_attr(feature = "rustcrypto-hmac", case::rustcrypto(rustcrypto_ctx()))]
 fn cose_examples_hmac_mac0_self_signed<B: MacCryptoBackend>(
-    #[files("tests/cose_examples/hmac-examples/HMac-enc-0[0-4].json")] test_path: PathBuf,
-    #[case] backend: B,
-) {
-    test_helper::perform_cose_self_signed_test::<CoseMac0, B>(test_path, backend);
-}
-
-// As of now, RustCrypto does not support HMAC 256/64, so we must only perform this test with
-// OpenSSL.
-//
-// Once RustCrypto supports this algorithm, we can merge this test with
-// cose_examples_hmac_mac0_reference_output.
-#[rstest]
-#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
-fn cose_examples_hmac256_64_mac0_reference_output<B: MacCryptoBackend>(
-    #[files("tests/cose_examples/hmac-examples/HMac-enc-05.json")] test_path: PathBuf,
-    #[case] backend: B,
-) {
-    test_helper::perform_cose_reference_output_test::<CoseMac0, B>(test_path, backend);
-}
-
-// As of now, RustCrypto does not support HMAC 256/64, so we must only perform this test with
-// OpenSSL.
-//
-// Once RustCrypto supports this algorithm, we can merge this test with
-// cose_examples_hmac_mac0_self_signed.
-#[rstest]
-#[cfg_attr(feature = "openssl", case::openssl(openssl_ctx()))]
-fn cose_examples_hmac256_64_mac0_self_signed<B: MacCryptoBackend>(
-    #[files("tests/cose_examples/hmac-examples/HMac-enc-05.json")] test_path: PathBuf,
+    #[files("tests/cose_examples/hmac-examples/HMac-enc-0[0-5].json")] test_path: PathBuf,
     #[case] backend: B,
 ) {
     test_helper::perform_cose_self_signed_test::<CoseMac0, B>(test_path, backend);

--- a/src/token/cose/maced/mod.rs
+++ b/src/token/cose/maced/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 The NAMIB Project Developers.
+ * Copyright (c) 2024-2025 The NAMIB Project Developers.
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
  * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -167,7 +167,8 @@ fn try_compute<B: MacCryptoBackend, CKP: KeyProvider>(
             let parsed_key = CoseParsedKey::try_from(key)?;
 
             match alg {
-                iana::Algorithm::HMAC_256_256
+                iana::Algorithm::HMAC_256_64
+                | iana::Algorithm::HMAC_256_256
                 | iana::Algorithm::HMAC_384_384
                 | iana::Algorithm::HMAC_512_512 => {
                     let symm_key = ensure_valid_hmac_key(alg, parsed_key)?;
@@ -207,7 +208,8 @@ pub(crate) fn try_verify<B: MacCryptoBackend, CKP: KeyProvider>(
             let parsed_key = CoseParsedKey::try_from(key)?;
 
             match alg {
-                iana::Algorithm::HMAC_256_256
+                iana::Algorithm::HMAC_256_64
+                | iana::Algorithm::HMAC_256_256
                 | iana::Algorithm::HMAC_384_384
                 | iana::Algorithm::HMAC_512_512 => {
                     let symm_key = ensure_valid_hmac_key(alg, parsed_key)?;

--- a/src/token/cose/test_helper.rs
+++ b/src/token/cose/test_helper.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 The NAMIB Project Developers.
+ * Copyright (c) 2024-2025 The NAMIB Project Developers.
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
  * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -129,6 +129,7 @@ fn string_to_algorithm<'de, D: Deserializer<'de>>(
         Some("A128KW") => Ok(Some(iana::Algorithm::A128KW)),
         Some("A192KW") => Ok(Some(iana::Algorithm::A192KW)),
         Some("A256KW") => Ok(Some(iana::Algorithm::A256KW)),
+        Some("HS256/64") => Ok(Some(iana::Algorithm::HMAC_256_64)),
         Some("HS256") => Ok(Some(iana::Algorithm::HMAC_256_256)),
         Some("HS384") => Ok(Some(iana::Algorithm::HMAC_384_384)),
         Some("HS512") => Ok(Some(iana::Algorithm::HMAC_512_512)),


### PR DESCRIPTION
Just to get back into working on `dcaf-rs`, this small PR adds support for HMAC 256/64 (i.e., HMAC with SHA-256 truncated to 64 bytes) to the COSE module and the OpenSSL crypto backend, which is part of #17.

~~Unfortunately, support for the RustCrypto backend is not possible as of now, because the SHA256 implementation in RustCrypto [only supports 28 B or 32 B output/truncation lengths](https://docs.rs/sha2/latest/sha2/struct.Sha256VarCore.html).~~ Edit: Disregard, I might have missed that there is a separate function for handling truncated MACs (https://docs.rs/cbc-mac/latest/cbc_mac/trait.Mac.html#tymethod.verify_truncated_left).
