### PR TITLE
Bump rand to fix GHSA-cq8v-f236-94qc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ derive_builder = { version = "0.20", default-features = false, features = ["allo
 strum = { version = "0.26", default-features = false, features = ["derive"] }
 strum_macros = { version = "0.26", default-features = false }
 enumflags2 = { version = "^0.7", default-features = false }
-rand = { version = "^0.8", default-features = false }
+rand = { version = "^0.9.3", default-features = false }
 openssl = { version = "^0.10", optional = true }
 lazy_static = "1.4.0"
 aes-gcm = { version = "0.10.3", optional = true, default-features = false, features = ["alloc", "aes"] }
@@ -67,7 +67,7 @@ hex = { version = "^0.4", features = ["serde"] }
 base64 = "0.22.1"
 rstest = "0.22.0"
 serde_json = "1.0.118"
-rand = { version = "^0.8", default-features = false, features = ["std_rng", "std"] }
+rand = { version = "^0.9.3", default-features = false, features = ["std_rng", "std", "thread_rng"] }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"

--- a/src/token/cose/test_helper.rs
+++ b/src/token/cose/test_helper.rs
@@ -636,5 +636,5 @@ pub(crate) fn openssl_ctx() -> OpensslContext {
 #[cfg(rustcrypto_base)]
 #[fixture]
 pub(crate) fn rustcrypto_ctx() -> RustCryptoContext<ThreadRng> {
-    RustCryptoContext::new(rand::thread_rng())
+    RustCryptoContext::new(rand::rng())
 }

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -228,7 +228,7 @@ fn test_get_headers_invalid() {
 #[test]
 fn test_encrypt_decrypt(
 ) -> Result<(), AccessTokenError<<MockCipher<ThreadRng> as CryptoBackend>::Error>> {
-    let mut backend = MockCipher::<ThreadRng>::new(rand::thread_rng());
+    let mut backend = MockCipher::<ThreadRng>::new(rand::rng());
     let key = example_key_one(A128GCM);
     let (unprotected_header, protected_header) = example_headers(A128GCM, true);
     let claims = example_claims(&key)?;
@@ -255,7 +255,7 @@ fn test_encrypt_decrypt(
 fn test_encrypt_decrypt_multiple(
 ) -> Result<(), AccessTokenError<<MockCipher<ThreadRng> as CryptoBackend>::Error>> {
     const AUDIENCE: &str = "example_aud";
-    let mut backend = MockCipher::<ThreadRng>::new(rand::thread_rng());
+    let mut backend = MockCipher::<ThreadRng>::new(rand::rng());
     let (unprotected_header, protected_header) = example_headers(A128GCM, true);
     let key1 = example_key_one(A128KW);
     let key2 = example_key_two(A128KW);
@@ -310,7 +310,7 @@ fn test_encrypt_decrypt_multiple(
 #[test]
 fn test_encrypt_decrypt_match_multiple(
 ) -> Result<(), AccessTokenError<<MockCipher<ThreadRng> as CryptoBackend>::Error>> {
-    let mut backend = MockCipher::<ThreadRng>::new(rand::thread_rng());
+    let mut backend = MockCipher::<ThreadRng>::new(rand::rng());
     let (unprotected_header, protected_header) = example_headers(A128GCM, true);
     let key1 = example_key_one(A128KW);
     let aad = example_aad();
@@ -335,7 +335,7 @@ fn test_encrypt_decrypt_match_multiple(
 #[test]
 fn test_encrypt_decrypt_invalid_header(
 ) -> Result<(), AccessTokenError<<MockCipher<ThreadRng> as CryptoBackend>::Error>> {
-    let mut backend = MockCipher::<ThreadRng>::new(rand::thread_rng());
+    let mut backend = MockCipher::<ThreadRng>::new(rand::rng());
     let key = example_key_one(A128GCM);
     let (unprotected_header, protected_header) = example_headers(A128GCM, true);
     let (unprotected_invalid, protected_invalid) = example_invalid_headers();
@@ -388,7 +388,7 @@ fn test_encrypt_decrypt_invalid_header(
 #[test]
 fn test_sign_verify(
 ) -> Result<(), AccessTokenError<<MockCipher<ThreadRng> as CryptoBackend>::Error>> {
-    let mut backend = MockCipher::<ThreadRng>::new(rand::thread_rng());
+    let mut backend = MockCipher::<ThreadRng>::new(rand::rng());
     let key = example_ec_key_one(ES256);
     let (unprotected_header, protected_header) = example_headers(ES256, false);
     let claims = example_claims(&key)?;
@@ -416,7 +416,7 @@ fn test_sign_verify(
 fn test_sign_verify_multiple(
 ) -> Result<(), AccessTokenError<<MockCipher<ThreadRng> as CryptoBackend>::Error>> {
     const AUDIENCE: &str = "example_aud";
-    let mut backend = MockCipher::<ThreadRng>::new(rand::thread_rng());
+    let mut backend = MockCipher::<ThreadRng>::new(rand::rng());
     let key1 = example_ec_key_one(ES256);
     let key2 = example_ec_key_two(ES384);
     let invalid_key1 = CoseKeyBuilder::new_symmetric_key(vec![0; 5])


### PR DESCRIPTION
This PR bumps the `rand` crate to fix a soundness issue (GHSA-cq8v-f236-94qc) when the random number generator provided by `rand` is used by a custom logging implementation.

~~Additionally, it removes some `#[must_use]` annotations from trait implementations, as this is no longer supported by the compiler (see below):~~ (has already been fixed in a previous PR, i simply forgot to pull `main` before branching).
<img width="1404" height="226" alt="grafik" src="https://github.com/user-attachments/assets/cfb9ab89-42b7-4ad0-a1f1-38594ad9de13" />
